### PR TITLE
Fix(CI): Correct AMReX includes for v23.11 compatibility

### DIFF
--- a/containers/Singularity.deps.def
+++ b/containers/Singularity.deps.def
@@ -139,13 +139,6 @@ From: quay.io/rockylinux/rockylinux:8 # Using Quay.io
     echo "--- Building AMReX ${AMREX_VERSION} ---"
     git clone --depth 1 --branch ${AMREX_VERSION} https://github.com/AMReX-Codes/amrex.git
     cd amrex
-
-    # --- Check Source Tree --- ADDED THIS BLOCK ---
-    echo "--- Checking for AMReX_ParallelFor.H in SOURCE tree ---"
-    # Use find within the current directory (source directory)
-    find . -name AMReX_ParallelFor.H -ls || echo "--- WARNING: AMReX_ParallelFor.H not found in SOURCE tree! ---"
-    # --- End Source Check ---
-
     mkdir build && cd build
 
     echo "--- Configuring AMReX ---"
@@ -172,27 +165,12 @@ From: quay.io/rockylinux/rockylinux:8 # Using Quay.io
     echo "--- Building AMReX (make) ---"
     make -j$(nproc) || { echo "*** AMReX Make Failed!"; exit 1; }
 
-    # --- Pre-Install Check (in build directory) --- Retained ---
-    echo "--- Checking for AMReX_ParallelFor.H in build tree BEFORE install ---"
-    # Use find within the current directory (build directory)
-    find . -name AMReX_ParallelFor.H -ls || echo "--- WARNING: AMReX_ParallelFor.H not found in build tree before install! ---"
-    # --- End Pre-Install Check ---
-
     echo "--- Installing AMReX (make install) ---"
-    # Add VERBOSE=1 to the make install command
-    make install VERBOSE=1 || { echo "*** AMReX Make Install Failed!"; exit 1; }
+    # Removed VERBOSE=1
+    make install || { echo "*** AMReX Make Install Failed!"; exit 1; }
 
-    # --- Post-Install Check (in install directory) --- Retained ---
-    echo "--- Verifying AMReX header installation ---"
-    # Check specifically for the problematic header
-    find ${AMREX_INSTALL_PREFIX}/include -name AMReX_ParallelFor.H -print -quit | grep -q . || \
-      { echo "*** CRITICAL ERROR: AMReX_ParallelFor.H not found after install in ${AMREX_INSTALL_PREFIX}/include !"; \
-        echo "Listing contents of ${AMREX_INSTALL_PREFIX}/include:"; \
-        ls -lR ${AMREX_INSTALL_PREFIX}/include; \
-        exit 1; }
-    echo "--- AMReX_ParallelFor.H found in ${AMREX_INSTALL_PREFIX}/include ---"
-    # --- End Verification ---
-
+    # Removed specific checks for AMReX_ParallelFor.H
+    # Kept original general checks
 
     # Verification step (Your original checks are still good)
     echo "--- Checking AMReX installation contents in ${AMREX_INSTALL_PREFIX} ---"
@@ -292,11 +270,7 @@ From: quay.io/rockylinux/rockylinux:8 # Using Quay.io
     echo "Checking HYPRE lib (${HYPRE_INSTALL_PREFIX}/lib/libHYPRE.so)..."; ldd "${HYPRE_INSTALL_PREFIX}/lib/libHYPRE.so"
     echo "Checking OpenMPI lib (${OPENMPI_INSTALL_PREFIX}/lib/libmpi.so)..."; ldd "${OPENMPI_INSTALL_PREFIX}/lib/libmpi.so"
 
-    # Check AMReX header presence again in test, just in case
-    echo "--- Verifying AMReX header presence in test ---"
-    find ${AMREX_INSTALL_PREFIX}/include -name AMReX_ParallelFor.H -print -quit | grep -q . || \
-      { echo "*** TEST ERROR: AMReX_ParallelFor.H not found in ${AMREX_INSTALL_PREFIX}/include during test phase!"; exit 1; }
-    echo "--- AMReX_ParallelFor.H found during test phase ---"
+    # Removed the specific check for AMReX_ParallelFor.H in the test section
 
     echo "--- Basic dependency container tests passed. ---"
 

--- a/src/io/TiffReader.cpp
+++ b/src/io/TiffReader.cpp
@@ -22,8 +22,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Utility.H>          // Included for AMREX_ASSERT*
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_ParallelFor.H>      // For ParallelFor
-
+#include <AMReX_Loop.H> // For LoopOnCpu
 
 namespace OpenImpala {
 

--- a/src/io/tDatReader.cpp
+++ b/src/io/tDatReader.cpp
@@ -24,7 +24,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Utility.H> // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_ParallelFor.H>      // For ParallelFor
+#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
 // Default relative path to the sample DAT file
 const std::string default_dat_filename = "data/SampleData_2Phase.dat";

--- a/src/io/tHDF5Reader.cpp
+++ b/src/io/tHDF5Reader.cpp
@@ -24,7 +24,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Utility.H> // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_ParallelFor.H>      // For ParallelFor
+#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
 
 // Default relative path to the sample HDF5 file

--- a/src/io/tRawReader.cpp
+++ b/src/io/tRawReader.cpp
@@ -25,7 +25,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Utility.H>     // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_ParallelFor.H> // For ParallelFor copy
+#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
 // --- Default Test Parameters ---
 

--- a/src/io/tTiffReader.cpp
+++ b/src/io/tTiffReader.cpp
@@ -24,7 +24,7 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Utility.H>     // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_ParallelFor.H> // For ParallelFor copy
+#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
 // Default relative path to the sample TIFF file
 const std::string default_tiff_filename = "data/SampleData_2Phase.tif";


### PR DESCRIPTION
## Description

This PR fixes CI build failures encountered when compiling against the AMReX 23.11 dependency defined in the Singularity container. The build was failing during the `make` step with compiler errors indicating that the header file `AMReX_ParallelFor.H` could not be found.

## Diagnosis

Debugging revealed that `AMReX_ParallelFor.H` does not exist in the source code for the AMReX 23.11 release tag. However, several C++ source files (including `TiffReader.cpp` and `tDatReader.cpp`) were attempting to include this non-existent header.

## Changes Made

1.  **Corrected C++ Includes:**
    * Replaced `#include <AMReX_ParallelFor.H>` with the correct header `#include <AMReX_GpuLaunch.H>` in files that actually use the `amrex::ParallelFor` function (e.g., `tDatReader.cpp`).
    * Removed the incorrect `#include <AMReX_ParallelFor.H>` from files where it was included but `amrex::ParallelFor` was not used (e.g., `TiffReader.cpp`).
    * Ensured necessary headers like `<AMReX_Loop.H>` are included where needed (e.g., for `amrex::LoopOnCpu`).

2.  **Cleaned Singularity Definition File:**
    * Removed diagnostic checks (`find` commands for `AMReX_ParallelFor.H` in source, build, and install directories) from `containers/Singularity.deps.def` that were added during debugging.
    * Removed `VERBOSE=1` from the AMReX `make install` command in the `.def` file.
    * Removed the specific `%test` check for the non-existent header.

## Impact

These changes should resolve the compilation errors related to the missing header file and allow the CI build pipeline to proceed successfully when using the AMReX 23.11 dependency container. The Singularity container build itself remains robust but no longer contains the temporary diagnostic code.

*(Optional: Add "Closes #<issue_number>" if this PR addresses a specific GitHub issue)*