### PR TITLE
Fix(CI): Resolve Array4 reference binding errors and compiler warning

### DIFF
--- a/src/io/DatReader.cpp
+++ b/src/io/DatReader.cpp
@@ -132,7 +132,7 @@ bool DatReader::readFile(const std::string& filename)
     }
 
     try {
-        if (num_voxels > std::numeric_limits<size_t>::max()) {
+        if (static_cast<size_t>(num_voxels) > std::numeric_limits<size_t>::max()) {
              throw std::overflow_error("DatReader: Voxel count exceeds vector size limit.");
         }
         m_raw.resize(static_cast<size_t>(num_voxels));

--- a/src/io/tRawReader.cpp
+++ b/src/io/tRawReader.cpp
@@ -244,7 +244,7 @@ int main (int argc, char* argv[])
                 {
                     const amrex::Box& box = mfi.tilebox();
                     auto const& int_fab_arr = mf.const_array(mfi);
-                    auto&       real_fab_arr = mfv.array(mfi);
+                    auto       real_fab_arr = mfv.array(mfi);
                     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                     {
                         real_fab_arr(i, j, k) = static_cast<amrex::Real>(int_fab_arr(i, j, k));

--- a/src/io/tTiffReader.cpp
+++ b/src/io/tTiffReader.cpp
@@ -210,7 +210,7 @@ int main (int argc, char* argv[])
                 {
                     const amrex::Box& box = mfi.tilebox();
                     auto const& int_fab_arr = mf.const_array(mfi);
-                    auto&       real_fab_arr = mfv.array(mfi);
+                    auto       real_fab_arr = mfv.array(mfi);
                     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                     {
                         real_fab_arr(i, j, k) = static_cast<amrex::Real>(int_fab_arr(i, j, k));


### PR DESCRIPTION
## Description

This PR addresses C++ compilation issues identified after fixing the initial `AMReX_ParallelFor.H` header include error. The CI build was still failing due to errors related to reference binding, and a compiler warning was present.

## Changes Made

1.  **Fixed Array4 Reference Binding Errors:**
    * **Files Affected:** `src/io/tRawReader.cpp` (approx. line 247), `src/io/tTiffReader.cpp` (approx. line 213).
    * **Error:** `cannot bind non-const lvalue reference of type 'amrex::Array4<...>&' to an rvalue of type 'amrex::Array4<...>'`
    * **Cause:** The code used `auto& var = multifab.array(mfi);`. The `multifab.array(mfi)` method returns a temporary `Array4` view (an rvalue), which cannot be bound to a non-const lvalue reference (`auto&`).
    * **Solution:** Changed the declarations to `auto var = multifab.array(mfi);` (removing the `&`) to correctly capture the `Array4` view by value.

2.  **Fixed Sign-Compare Compiler Warning:**
    * **File Affected:** `src/io/DatReader.cpp` (line 135).
    * **Warning:** `[-Wsign-compare]` when comparing `num_voxels` (`amrex::Long`, signed) with `std::numeric_limits<size_t>::max()` (unsigned).
    * **Solution:** Added `static_cast<size_t>(...)` to `num_voxels` within the comparison: `if (static_cast<size_t>(num_voxels) > std::numeric_limits<size_t>::max())`. This makes the types consistent for the comparison and silences the warning.

## Impact

These changes resolve the C++ compilation errors and the sign-compare warning reported by the compiler (GCC 11). The CI build should now compile these files successfully.

*(Optional: Add "Closes #<issue_number>" if this PR addresses a specific GitHub issue)*