### PR TITLE
Fix Syntax Errors in Tortuosity_poisson_3d_F.H

### DIFF
--- a/src/props/Tortuosity_poisson_3d_F.H
+++ b/src/props/Tortuosity_poisson_3d_F.H
@@ -128,6 +128,3 @@ void tortuosity_poisson_fio (const int* lo, const int* hi,
 #endif
 
 #endif // TORTUOSITY_POISSON_F_H_
-```
-
-Now the C++ declaration matches the updated Fortran `bind(c)` interface. Remember you still need to update the actual C++ *call* to this function in `TortuosityDirect.cpp` to pass the number of componen


### PR DESCRIPTION
Resolve C++ compilation errors caused by invalid syntax in the Fortran C interface header file `Tortuosity_poisson_3d_F.H`.

Extraneous non-code text (Markdown backticks and comments accidentally introduced during previous edits) was removed from the file. This stray text caused "stray '`'" and "'Now' does not name a type" compilation errors when C++ files included this header.

This cleanup ensures the header contains only valid C/C++ declarations and preprocessor directives.

**Files Modified:**

* `src/props/Tortuosity_poisson_3d_F.H`