### PR TITLE
Fix(test): Correct tHDF5Reader execution via ParmParse config

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -102,25 +102,57 @@ main: $(APP_DIR)/Diffusion
 TEST_EXECS := $(patsubst src/props/%.cpp,$(TST_DIR)/%,$(SOURCES_TST_CPP))
 tests: $(TEST_EXECS_IO) $(TEST_EXECS_PRP)
 
-# Target to run the tests after they are built
+# Target to run the tests after they are built, linking specific input files
 test: tests
 	@echo ""
 	@echo "--- Running Tests ---"
 	@passed_all=true; \
 	list_of_tests='$(TEST_EXECS_IO) $(TEST_EXECS_PRP)'; \
+	# Ensure no stale './inputs' link exists before starting the loop
+	rm -f ./inputs; \
 	if [ -z "$$list_of_tests" ]; then \
 	    echo "No test executables found to run."; \
 	else \
+	    # Loop through each test executable (e.g., build/tests/tHDF5Reader)
 	    for tst in $$list_of_tests; do \
 	        echo "Running test $$tst..."; \
+	        # Get the base name of the test executable (e.g., tHDF5Reader)
+	        test_name=$$(basename $$tst); \
+	        # Define the path to the expected input file for this specific test
+	        input_file="tests/inputs/$${test_name}.inputs"; \
+	        \
+	        # Check if the specific input file exists
+	        if [ -f "$$input_file" ]; then \
+	            echo "  Using input file: $$input_file"; \
+	            # Create a symbolic link named 'inputs' in the Current Working Directory (CWD)
+	            # pointing to the specific test input file. AMReX ParmParse reads './inputs'.
+	            ln -sf "$$input_file" ./inputs; \
+	        else \
+	            # If no specific input file, decide how to handle it.
+	            # Option 1: Warn and proceed (test might fail or not need inputs)
+	            echo "  Warning: No specific input file found at $$input_file. Running without './inputs'."; \
+	            # Ensure no link exists from a previous iteration if file not found this time
+	            rm -f ./inputs; \
+	            # Option 2: Fail the test immediately (Uncomment below, comment out echo/rm above)
+	            # echo "  ERROR: Required input file $$input_file not found for test $$test_name!"; \
+	            # passed_all=false; \
+	            # continue; # Skip to the next test in the loop
+	        fi; \
+	        \
+	        # Run the actual test using mpirun.
+	        # The test executable will now find './inputs' which points to the correct file.
 	        if mpirun -np 1 --allow-run-as-root $$tst; then \
 	            echo "  PASS: $$tst"; \
 	        else \
 	            echo "  FAIL: $$tst"; \
 	            passed_all=false; \
 	        fi; \
+	        \
+	        # IMPORTANT: Clean up the symbolic link before the next test runs
+	        rm -f ./inputs; \
 	    done; \
 	fi; \
+	# Summarize results and exit with appropriate status code
 	echo "--- Test Summary ---"; \
 	if $$passed_all; then \
 	    echo "All tests passed."; \

--- a/src/io/tHDF5Reader.cpp
+++ b/src/io/tHDF5Reader.cpp
@@ -8,9 +8,10 @@
 #include <iomanip>   // For std::setw, std::setfill
 #include <ctime>
 #include <memory>    // For std::unique_ptr, std::make_unique
+#include <sstream>   // For std::stringstream
 
 #include <AMReX.H>
-#include <AMReX_ParmParse.H> // For reading command-line arguments
+#include <AMReX_ParmParse.H> // For reading input files
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_Box.H>
@@ -22,18 +23,13 @@
 #include <AMReX_CoordSys.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_PlotFileUtil.H>
-#include <AMReX_Utility.H> // For amrex::UtilCreateDirectory
-#include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
+#include <AMReX_Utility.H> // For amrex::UtilCreateDirectory, amrex::Concatenate
+#include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier, MyProc
 #include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
-
-// Default relative path to the sample HDF5 file
-const std::string default_hdf5_filename = "data/SampleData_2Phase.h5";
-// Default dataset path within the HDF5 file
-const std::string default_hdf5_dataset = "exchange/data";
 // Output directory relative to executable location
 const std::string test_output_dir = "tHDF5Reader_output";
-// Define Box size for breaking down domain
+// Define Box size for breaking down domain (can also be read from inputs)
 const int BOX_SIZE = 32;
 
 int main (int argc, char* argv[])
@@ -43,163 +39,212 @@ int main (int argc, char* argv[])
     // Use a block for AMReX object lifetimes
     {
         // --- Input Parameters ---
-        std::string hdf5_filename = default_hdf5_filename;
-        std::string hdf5_dataset  = default_hdf5_dataset;
-        bool write_plotfile = false; // Default: don't write plotfile
+        // Declare variables, values MUST come from the 'inputs' file via ParmParse
+        std::string hdf5_filename;
+        std::string hdf5_dataset;
+        bool write_plotfile = false; // Default: don't write plotfile unless specified in inputs
+        int box_size = BOX_SIZE;     // Default box size, can be overridden
+        double threshold_value = 1.0; // Default threshold, can be overridden
 
-        { // Use ParmParse to read parameters from command line
-            amrex::ParmParse pp;
-            pp.query("hdf5file", hdf5_filename);
-            pp.query("dataset", hdf5_dataset);
-            pp.query("write_plotfile", write_plotfile);
+        { // Use ParmParse to read parameters from the 'inputs' file
+            amrex::ParmParse pp; // Default scope, reads global parameters from ./inputs
+
+            // *** USE CORRECT PARAMETER NAMES and REQUIRE them using get() ***
+            // The program will abort via amrex::Error if these are not found.
+            pp.get("filename", hdf5_filename);     // EXPECTS 'filename = /path/to/file.h5' in inputs
+            pp.get("hdf5_dataset", hdf5_dataset); // EXPECTS 'hdf5_dataset = /internal/path' in inputs
+
+            // query() is suitable for optional parameters or those with reasonable defaults
+            pp.query("write_plotfile", write_plotfile); // Optional: 'write_plotfile = 1'
+            pp.query("box_size", box_size);             // Optional: 'box_size = 64'
+            pp.query("threshold_value", threshold_value); // Optional: 'threshold_value = 0.5'
         }
 
-        // Check if input file exists before attempting to read
+        // Simple check if input file exists (HDF5Reader will also check)
         {
             std::ifstream test_ifs(hdf5_filename);
             if (!test_ifs) {
-                 amrex::Abort("Error: Cannot open input hdf5file: " + hdf5_filename + "\n"
-                              "       Specify path using 'hdf5file=/path/to/file.h5'");
+                 amrex::Error("Error: Cannot open input file specified by 'filename': " + hdf5_filename + "\n"
+                              "       Ensure './inputs' file exists and specifies correct path.");
             }
         }
 
-        amrex::Print() << "Starting tHDF5Reader Test (Compiled: " << __DATE__ << " " << __TIME__ << ")\n";
-        amrex::Print() << "Input HDF5 file: " << hdf5_filename << "\n";
-        amrex::Print() << "Input dataset path: " << hdf5_dataset << "\n";
-        amrex::Print() << "Write plot file: " << (write_plotfile ? "Yes" : "No") << "\n";
+        // Only IOProcessor should print parameter summary
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "Starting tHDF5Reader Test (Compiled: " << __DATE__ << " " << __TIME__ << ")\n";
+            amrex::Print() << "Input HDF5 file (from inputs): " << hdf5_filename << "\n";
+            amrex::Print() << "Input dataset path (from inputs): " << hdf5_dataset << "\n";
+            amrex::Print() << "Threshold value: " << threshold_value << "\n";
+            amrex::Print() << "Box size: " << box_size << "\n";
+            amrex::Print() << "Write plot file: " << (write_plotfile ? "Yes" : "No") << "\n";
+        }
 
         // --- Test HDF5Reader ---
         std::unique_ptr<OpenImpala::HDF5Reader> reader_ptr;
+        // Expected dimensions might also come from inputs if testing different files
         int expected_width = 100;
         int expected_height = 100;
         int expected_depth = 100;
 
-        // <<< FIX: Declare threshold_value using the DataType alias from HDF5Reader.H >>>
-        const OpenImpala::HDF5Reader::DataType threshold_value = 1; // Use the type defined in HDF5Reader.H
-
         try {
+            // HDF5Reader constructor now receives paths read from the inputs file
             reader_ptr = std::make_unique<OpenImpala::HDF5Reader>(hdf5_filename, hdf5_dataset);
         } catch (const std::exception& e) {
-            amrex::Abort("Error creating HDF5Reader: " + std::string(e.what()));
+            amrex::Error("Error creating HDF5Reader: " + std::string(e.what()));
+        }
+
+        // Check if reader was successfully created and read data
+        if (!reader_ptr || !reader_ptr->isRead()) {
+             amrex::Error("HDF5Reader object creation or file read failed after construction.");
         }
 
         // --- Check Dimensions & Metadata ---
-        amrex::Print() << "Checking dimensions and metadata...\n";
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+             amrex::Print() << "Checking dimensions and metadata...\n";
+        }
         int actual_width = reader_ptr->width();
         int actual_height = reader_ptr->height();
         int actual_depth = reader_ptr->depth();
 
-        // Keep calls to non-existent member functions commented out
-        // int actual_bps = reader_ptr->bitsPerSample();
-        // int actual_format = reader_ptr->sampleFormat();
-        // int actual_spp = reader_ptr->samplesPerPixel();
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x" << actual_depth << "\n";
+            amrex::Print() << "  (Skipping metadata checks for BPS, Format, SPP as methods are not implemented in HDF5Reader).\n";
+        }
 
-        amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x" << actual_depth << "\n";
-        // amrex::Print() << "  Read metadata: BPS=" << actual_bps << ", Format=" << actual_format << ", SPP=" << actual_spp << "\n"; // Commented out
-
+        // Perform check on all ranks to ensure consistency, abort on any failure
         if (actual_width != expected_width || actual_height != expected_height || actual_depth != expected_depth) {
-            amrex::Abort("FAIL: Read dimensions do not match expected dimensions (100x100x100).");
+            // Use a stringstream to format the error message before calling amrex::Error
+            // This prevents potential issues with parallel printing inside amrex::Error arguments.
+            std::stringstream ss;
+            ss << "FAIL: Read dimensions (" << actual_width << "x" << actual_height << "x" << actual_depth
+               << ") do not match expected dimensions (" << expected_width << "x" << expected_height << "x" << expected_depth << ").";
+            amrex::Error(ss.str()); // Use Error for test failure, safe for parallel calls
         }
 
-        // Keep checks related to non-existent member functions commented out
-        /*
-        // int expected_bps = 8; // Example value
-        // int expected_format = 1; // Example value
-        // int expected_spp = 1; // Example value
-        if (actual_bps != expected_bps) {
-             amrex::Abort("FAIL: Read BitsPerSample (" + std::to_string(actual_bps) +
-                          ") does not match expected value (" + std::to_string(expected_bps) + ").");
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Dimension check passed.\n";
         }
-        if (actual_format != expected_format) {
-             amrex::Abort("FAIL: Read SampleFormat (" + std::to_string(actual_format) +
-                          ") does not match expected value (" + std::to_string(expected_format) + ").");
-        }
-        if (actual_spp != expected_spp) {
-             amrex::Abort("FAIL: Read SamplesPerPixel (" + std::to_string(actual_spp) +
-                          ") does not match expected value (" + std::to_string(expected_spp) + ").");
-        }
-        */
-        amrex::Print() << "  Dimension check passed.\n";
-        amrex::Print() << "  (Skipping metadata checks for BPS, Format, SPP as methods are not implemented in HDF5Reader).\n";
+
 
         // --- Setup AMReX Data Structures ---
         amrex::Geometry geom;
         amrex::Box domain_box = reader_ptr->box();
         {
-            amrex::RealBox rb({0.0, 0.0, 0.0}, {1.0, 1.0, 1.0});
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0};
-            amrex::Geometry::Setup(&rb, 0, is_periodic.data());
-            geom.define(domain_box);
+            // Using RealBox based on domain size; could also read physical size from attributes/inputs
+            amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
+                              {AMREX_D_DECL(amrex::Real(domain_box.length(0)),
+                                            amrex::Real(domain_box.length(1)),
+                                            amrex::Real(domain_box.length(2)))});
+            amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0}; // Assuming non-periodic
+            geom.define(domain_box, &rb, amrex::CoordSys::cartesian, is_periodic.data());
         }
 
         amrex::BoxArray ba(domain_box);
-        ba.maxSize(BOX_SIZE);
+        ba.maxSize(box_size); // Use value read from inputs
         amrex::DistributionMapping dm(ba);
 
+        // iMultiFab for threshold result (integer: 0 or 1)
+        // 0 ghost cells needed as input for VolumeFraction/Tortuosity usually
         amrex::iMultiFab mf(ba, dm, 1, 0);
-        mf.setVal(0);
+        mf.setVal(0); // Initialize
 
         // --- Test Thresholding ---
-        // threshold_value is now HDF5Reader::DataType, but threshold() takes double. C++ handles implicit conversion.
-        amrex::Print() << "Performing threshold > " << threshold_value << "...\n";
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "Performing threshold > " << threshold_value << "...\n";
+        }
         try {
-            reader_ptr->threshold(static_cast<double>(threshold_value), mf); // Pass as double explicitly if needed, else rely on implicit conversion
+            // HDF5Reader::threshold takes double.
+            reader_ptr->threshold(threshold_value, mf);
         } catch (const std::exception& e) {
-            amrex::Abort("Error during threshold operation: " + std::string(e.what()));
+            amrex::Error("Error during threshold operation: " + std::string(e.what()));
         }
 
-        int min_val = mf.min(0);
-        int max_val = mf.max(0);
-        amrex::Print() << "  Threshold result min value: " << min_val << "\n";
-        amrex::Print() << "  Threshold result max value: " << max_val << "\n";
+        // --- Check Threshold Result ---
+        // Use global reductions for min/max across all MPI ranks
+        int min_val = mf.min(0, 0, true); // component 0, 0 ghost cells, local=false for global min
+        int max_val = mf.max(0, 0, true); // component 0, 0 ghost cells, local=false for global max
 
-        if (min_val != 0 || max_val != 1) {
-             amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
-                            << ") not the expected 0/1. Check threshold value or sample data.\n";
-        } else {
-             amrex::Print() << "  Threshold value range looks plausible (0 and 1 found).\n";
+        // Only IOProcessor should print results of reductions and check plausibility
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Threshold result min value (global): " << min_val << "\n";
+            amrex::Print() << "  Threshold result max value (global): " << max_val << "\n";
+
+            // Check threshold result plausibility (adjust if thresholding logic changes)
+            if (min_val != 0 || max_val != 1) {
+                 amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
+                                << ") not the expected 0/1. Check threshold value or sample data.\n";
+                 // Consider making this a failure? Depends on test requirements.
+                 // amrex::Error("FAIL: Unexpected min/max values after thresholding.");
+            } else {
+                 amrex::Print() << "  Threshold value range looks plausible (0 and 1 found globally).\n";
+            }
         }
 
         // --- Optional: Write Plotfile ---
         if (write_plotfile) {
-            amrex::Print() << "Writing plot file...\n";
+            std::string plotfilename; // Declare outside the block
+
+            // Create directory only on IOProcessor
             if (amrex::ParallelDescriptor::IOProcessor()) {
+                 amrex::Print() << "Attempting to create plotfile output directory...\n";
                  if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
-                     amrex::Warning("Could not create output directory: " + test_output_dir);
+                     // Warning is okay if directory already exists
+                     amrex::Print() << "Warning: Could not create output directory (it might already exist): " << test_output_dir << "\n";
                  }
             }
+            // Ensure directory exists before proceeding (all ranks wait)
             amrex::ParallelDescriptor::Barrier();
 
-            std::string datetime_str;
+            // Construct plotfile name (potentially include rank for parallel consistency)
             {
-                std::time_t strt_time; std::tm* timeinfo; char datetime_buf [80];
-                std::time(&strt_time); timeinfo = std::localtime(&strt_time);
-                std::strftime(datetime_buf, sizeof(datetime_buf),"%Y%m%d%H%M",timeinfo);
-                datetime_str = datetime_buf;
-            }
-            std::string plotfilename = test_output_dir + "/hdf5readertest_" + datetime_str;
+                std::string datetime_str;
+                std::time_t now_time = std::time(nullptr);
+                std::tm* now_tm = std::localtime(&now_time);
+                if (now_tm) {
+                    char datetime_buf[80];
+                    // Use underscore for better filename compatibility
+                    std::strftime(datetime_buf, sizeof(datetime_buf),"%Y%m%d_%H%M%S", now_tm);
+                    datetime_str = datetime_buf;
+                } else {
+                    datetime_str = "time_error";
+                }
+                // Example: plt00000 or a name including rank/time
+                // Using Concatenate adds leading zeros based on step number (using 0 here)
+                plotfilename = amrex::Concatenate(test_output_dir + "/plt_hdf5_", 0, 5);
+                plotfilename += "_" + datetime_str; // Append timestamp
 
-            amrex::MultiFab mfv(ba, dm, 1, 0);
-            for (amrex::MFIter mfi(mfv, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            } // End block for time variables
+
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "Writing plot file to: " << plotfilename << "\n";
+            }
+
+            // Create a MultiFab view of the iMultiFab for plotting
+            amrex::MultiFab mfv(ba, dm, 1, 0); // Real MultiFab, 0 ghost cells
+
+            // Copy integer data to real data (simple cast) using ParallelFor
+            amrex::ParallelFor(mfv, mf.nGrowVect(), [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
             {
-                const amrex::Box& box = mfi.tilebox();
-                auto const& int_fab = mf.const_array(mfi);
-                // Keep fix changing auto& to auto
-                auto real_fab = mfv.array(mfi);
+                const auto& int_fab = mf.const_array(box_no); // Get const Array4 for iMultiFab
+                auto real_fab = mfv.array(box_no);            // Get Array4 for MultiFab
+                real_fab(i,j,k) = static_cast<amrex::Real>(int_fab(i,j,k)); // Cast and assign
+            });
 
-                amrex::ParallelFor(box, [&] (int i, int j, int k) noexcept
-                {
-                    real_fab(amrex::IntVect(i,j,k)) = static_cast<amrex::Real>(int_fab(amrex::IntVect(i,j,k)));
-                });
-            }
+            // Write plot file (step=0, time=0.0 are placeholders)
             amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0, 0);
-            amrex::Print() << "  Plot file written to: " << plotfilename << "\n";
+
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "  Plot file written.\n";
+            }
         }
 
-        amrex::Print() << "tHDF5Reader Test Completed Successfully.\n";
+        // If we reached here without amrex::Error, the test passed conceptually
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "tHDF5Reader Test Completed Successfully.\n";
+        }
 
     } // End AMReX scope block
 
     amrex::Finalize();
-    return 0;
+    return 0; // Return 0 indicates success to the shell/Makefile
 }

--- a/tests/inputs/tHDF5Reader.inputs
+++ b/tests/inputs/tHDF5Reader.inputs
@@ -1,0 +1,20 @@
+# ============================================================
+# Input file for the tHDF5Reader test
+# Specifies the literal dataset path including special characters.
+# ============================================================
+
+# --- Required Parameters ---
+
+# Specifies the HDF5 file to be read by the test.
+filename     = data/SampleData_2Phase.h5
+
+# Specifies the LITERAL internal path to the 3D dataset within the HDF5 file.
+# This includes the '$' characters exactly as they appear in the file.
+hdf5_dataset = /t$F/channel$C
+
+
+# --- Optional Parameters ---
+# verbose = 1
+# box_size = 32
+# threshold_value = 1.0 # Adjust based on data in the dataset named /t$F/channel$C
+# write_plotfile = 0


### PR DESCRIPTION
# Fix(test): Correct tHDF5Reader execution via ParmParse config

## Description

This PR addresses the failing `tHDF5Reader` test in the CI pipeline by correcting its configuration mechanism. It also refactors the `make test` execution process to support specific input files for individual tests, establishing a pattern for other tests.

**Problem:**

1.  The `tHDF5Reader` test was failing because it relied on an incorrect, hardcoded default HDF5 dataset path (`exchange/data`) instead of the actual path (`/t$F/channel$C`).
2.  The test used `ParmParse` keys (`hdf5file`, `dataset`) that were inconsistent with the main application (`filename`, `hdf5_dataset`).
3.  The `make test` target lacked a mechanism to supply unique `inputs` files to different tests, preventing proper configuration via `ParmParse`.

**Changes Included:**

1.  **`src/io/tHDF5Reader.cpp`:**
    * Removed hardcoded default values for filename and dataset path.
    * Updated `amrex::ParmParse` calls to use `pp.get()` with the correct keys (`filename`, `hdf5_dataset`) matching `Diffusion.cpp`, ensuring parameters are required from the input file.
2.  **`tests/inputs/tHDF5Reader.inputs` (New File):**
    * Added a dedicated input configuration file specifically for the `tHDF5Reader` test.
    * Specifies the correct HDF5 `filename` (`data/SampleData_2Phase.h5`) and the literal `hdf5_dataset` path (`/t$F/channel$C`).
3.  **`Makefile`:**
    * Modified the `test` target's shell script logic.
    * The script now identifies the specific input file for each test within the `tests/inputs/` directory (based on the test executable name, e.g., `tests/inputs/tHDF5Reader.inputs`).
    * It creates a symbolic link named `./inputs` pointing to the correct file *before* running the corresponding test executable.
    * It removes the `./inputs` symbolic link *after* the test finishes, ensuring a clean state for the next test.

**How it Fixes the Issue:**

The updated `tHDF5Reader.cpp` now correctly reads its required configuration (`filename` and the literal `hdf5_dataset` path) from an `inputs` file using standard parameter names. The modified `Makefile` ensures that when `make test` runs `tHDF5Reader`, the file `./inputs` is temporarily linked to `tests/inputs/tHDF5Reader.inputs`, providing the correct parameters. This results in the `HDF5Reader` class being instantiated with the correct dataset path (`/t$F/channel$C`), resolving the "unable to open dataset" error.

**Impact:**

* Fixes the specific CI failure observed for the `tHDF5Reader` test.
* Improves the robustness and maintainability of the test suite by allowing explicit configuration per test.
* Provides a clear pattern for updating other tests (`tRawReader`, `tTortuosity`, etc.) to use `ParmParse` and dedicated input files correctly.

**Testing:**

These changes should resolve the specific HDF5 dataset path error observed for `tHDF5Reader` in CI runs when executed via `make test`. Further testing might be needed to confirm the underlying HDF5 file content and other test logic.

**(Optional: Link to Issue)**
*Closes #*<Issue_Number_If_Any>*