### PR TITLE
Refactor(IO): Overhaul TiffReader for Parallelism, Large Files, and Tiled Support

### DIFF
--- a/src/io/TiffReader.H
+++ b/src/io/TiffReader.H
@@ -1,64 +1,75 @@
-#ifndef TIFF_READER_H // Corrected header guard style
+#ifndef TIFF_READER_H
 #define TIFF_READER_H
 
-#include <vector>
 #include <string>
 #include <cstdint>   // For standard integer types
 #include <stdexcept> // For std::runtime_error
-#include <map>       // For attribute map
-#include <memory>    // For std::unique_ptr (used internally in .cpp)
+// #include <vector> // No longer needed for m_raw_bytes
+// #include <map>    // Only needed if attributes are implemented
 
 #include <AMReX_REAL.H>
 #include <AMReX_Box.H>
 #include <AMReX_iMultiFab.H>
 
-// Forward declare TIFF to avoid including tiffio.h in the header if possible
-// If TIFF* is used directly in public/protected interface, tiffio.h might be needed here
-// struct tiff; // Opaque struct forward declaration
-// typedef struct tiff TIFF; // Typedef for TIFF*
-// For simplicity now, assume tiffio.h is only needed in .cpp
+// Forward declare TIFF - not strictly necessary now as TIFF* isn't in the
+// public/protected interface, but can be kept for clarity if desired.
+// struct tiff;
+// typedef struct tiff TIFF;
 
 namespace OpenImpala {
 
 /**
- * @brief Reads 3D image data from single or multi-directory/multi-file TIFFs.
+ * @brief Reads 3D image data from single/multi-directory TIFFs or file sequences.
+ * Performs parallel, chunked reading directly into AMReX iMultiFab.
  *
- * This class uses libtiff to read TIFF files, including sequences or multi-directory
- * files representing a 3D volume. It handles various sample formats and bits per sample,
- * storing the data internally as raw bytes. Methods are provided for thresholding
- * into AMReX iMultiFabs and querying metadata.
+ * This class uses libtiff to read TIFF files (single stack files or sequences
+ * representing Z-slices). It is designed for parallel environments (MPI+OpenMP)
+ * and large datasets that may exceed single-node memory.
  *
- * @warning Only supports CONTIGUOUS planar configuration. Tiled TIFFs not supported.
- * @warning Reads entire dataset into memory - unsuitable for datasets exceeding RAM.
- * @warning Assumes serial I/O. Parallel reads require different strategies.
+ * Metadata (dimensions, data type) is read first by rank 0 and broadcast.
+ * Data reading is performed by the `threshold` methods, driven by the
+ * distribution of the target `iMultiFab`. Each MPI rank reads only the
+ * necessary strips or tiles for its owned boxes directly from the file(s).
+ * Supports Striped and Tiled TIFF formats.
+ *
+ * @warning Assumes serial libtiff calls internally. While reading is distributed
+ * across ranks via MFIter, concurrent libtiff calls from different
+ * threads within a rank to the SAME file handle might require a
+ * thread-safe libtiff build or external locking (current implementation
+ * uses per-thread handles for sequences, avoiding this issue there).
+ * @warning Assumes PLANARCONFIG_CONTIG. Multi-sample data is read, but only
+ * the first sample is used during thresholding.
  * @warning Copy operations disabled.
  */
 class TiffReader
 {
 public:
-    // Define the type used for internal byte storage
-    using ByteType = unsigned char;
-
     /**
-     * @brief Default constructor. Creates an empty reader.
+     * @brief Default constructor. Creates an empty reader. Use readFile() or readFileSequence().
      */
     TiffReader();
 
     /**
-     * @brief Constructs a TiffReader and reads a single (potentially multi-directory) TIFF file.
+     * @brief Constructs a TiffReader, reads metadata from a single (potentially multi-directory) TIFF file.
+     *
+     * Reads dimensions and data type info on rank 0 and broadcasts.
+     * Does NOT read pixel data. Throws on error.
      * @param filename Path to the TIFF file.
-     * @throws std::runtime_error on file open or read errors, or unsupported format.
+     * @throws std::runtime_error on file open or metadata read errors.
      */
     explicit TiffReader(const std::string& filename);
 
     /**
-     * @brief Constructs a TiffReader and reads a sequence of TIFF files.
+     * @brief Constructs a TiffReader, reads metadata from the first file of a sequence.
+     *
+     * Reads dimensions and data type info from the first file on rank 0 and broadcasts.
+     * Does NOT read pixel data. Throws on error.
      * @param base_pattern Base filename pattern (e.g., "path/slice_").
      * @param num_files Total number of files in the sequence (determines Z dimension).
      * @param start_index The starting number for the sequence (e.g., 0 or 1).
      * @param digits The number of digits used for the sequence number padding (e.g., 4 for "0001").
      * @param suffix File extension including dot (e.g., ".tif").
-     * @throws std::runtime_error on file open/read errors, inconsistent metadata, or unsupported format.
+     * @throws std::runtime_error on file open/metadata read errors or inconsistent metadata.
      */
     TiffReader(
         const std::string& base_pattern,
@@ -76,25 +87,32 @@ public:
     TiffReader(const TiffReader&) = delete;
     TiffReader& operator=(const TiffReader&) = delete;
 
-    // --- Optional: Default Move Operations ---
+    // --- Default Move Operations ---
     TiffReader(TiffReader&&) = default;
     TiffReader& operator=(TiffReader&&) = default;
 
     /**
-     * @brief Reads a single (potentially multi-directory) TIFF file. Clears existing data.
+     * @brief Reads metadata from a single (potentially multi-directory) TIFF file.
+     *
+     * Clears existing metadata. Rank 0 opens file, reads dimensions/type, validates,
+     * determines depth, and broadcasts info to all ranks. Does NOT read pixel data.
      * @param filename Path to the TIFF file.
-     * @return true on success, false otherwise. Prints errors via amrex::Print.
+     * @return true on success (metadata broadcast), false otherwise. Aborts on critical errors.
      */
     bool readFile(const std::string& filename);
 
     /**
-     * @brief Reads a sequence of TIFF files representing Z-slices. Clears existing data.
+     * @brief Reads metadata from the first file of a TIFF sequence.
+     *
+     * Clears existing metadata. Rank 0 opens first file, reads dimensions/type, validates,
+     * sets depth from num_files, and broadcasts info (including sequence params) to all ranks.
+     * Does NOT read pixel data.
      * @param base_pattern Base filename pattern (e.g., "path/slice_").
      * @param num_files Total number of files in the sequence (determines Z dimension).
      * @param start_index The starting number for the sequence (e.g., 0 or 1).
      * @param digits The number of digits used for the sequence number padding (e.g., 4 for "0001").
      * @param suffix File extension including dot (e.g., ".tif").
-     * @return true on success, false otherwise. Prints errors via amrex::Print.
+     * @return true on success (metadata broadcast), false otherwise. Aborts on critical errors.
      */
     bool readFileSequence(
         const std::string& base_pattern,
@@ -104,77 +122,91 @@ public:
         const std::string& suffix = ".tif");
 
     /**
-     * @brief Fills an iMultiFab based on thresholding the raw data. Output 1/0.
-     * @param raw_threshold Threshold value (compared against data converted to double).
-     * @param mf Output amrex::iMultiFab reference.
+     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding (output 1/0).
+     *
+     * Performs distributed reading. Iterates through the patches (`MFIter`) of the output
+     * iMultiFab `mf`. For each patch, reads the corresponding strips or tiles
+     * from the TIFF file(s) and fills the patch's FArrayBox based on the threshold.
+     * Sets output cells to 1 if `native_value > raw_threshold`, else 0.
+     * Requires metadata to have been read successfully first via readFile() or readFileSequence().
+     * Handles conversion from native TIFF type to double for comparison. Uses first sample if SPP > 1.
+     *
+     * @param raw_threshold The threshold value (compared against data converted to double).
+     * @param mf Output amrex::iMultiFab reference to fill (must be defined and distributed).
+     * @throws std::runtime_error on read errors or if metadata not ready.
      */
     void threshold(double raw_threshold, amrex::iMultiFab& mf) const;
 
     /**
-     * @brief Fills an iMultiFab based on thresholding with custom output values.
-     * @param raw_threshold Threshold value (compared against data converted to double).
+     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding with custom output values.
+     *
+     * Performs distributed reading. Iterates through the patches (`MFIter`) of the output
+     * iMultiFab `mf`. For each patch, reads the corresponding strips or tiles
+     * from the TIFF file(s) and fills the patch's FArrayBox based on the threshold.
+     * Sets output cells to `value_if_true` if `native_value > raw_threshold`, else `value_if_false`.
+     * Requires metadata to have been read successfully first via readFile() or readFileSequence().
+     * Handles conversion from native TIFF type to double for comparison. Uses first sample if SPP > 1.
+     *
+     * @param raw_threshold The threshold value (compared against data converted to double).
      * @param value_if_true Integer value if condition is true.
      * @param value_if_false Integer value if condition is false.
-     * @param mf Output amrex::iMultiFab reference.
+     * @param mf Output amrex::iMultiFab reference to fill (must be defined and distributed).
+     * @throws std::runtime_error on read errors or if metadata not ready.
      */
     void threshold(double raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const;
 
+    // --- Metadata Getters ---
     /** @brief Returns the index space Box covering the entire image domain [0, w-1]x[0, h-1]x[0, d-1]. */
     amrex::Box box() const;
 
-    /** @brief Get width (X-dimension) in pixels/voxels. */
+    /** @brief Get width (X-dimension) in pixels/voxels. Requires metadata to be read. */
     int width() const;
-    /** @brief Get height (Y-dimension) in pixels/voxels. */
+    /** @brief Get height (Y-dimension) in pixels/voxels. Requires metadata to be read. */
     int height() const;
-    /** @brief Get depth (Z-dimension) in pixels/voxels. */
+    /** @brief Get depth (Z-dimension) in pixels/voxels. Requires metadata to be read. */
     int depth() const;
 
-    // --- Metadata Getters ---
-    /** @brief Get bits per sample (e.g., 8, 16, 32). */
+    /** @brief Get bits per sample (e.g., 8, 16, 32). Requires metadata to be read. */
     int bitsPerSample() const;
-    /** @brief Get sample format (e.g., SAMPLEFORMAT_UINT, SAMPLEFORMAT_INT, SAMPLEFORMAT_IEEEFP). */
+    /** @brief Get sample format (e.g., SAMPLEFORMAT_UINT, SAMPLEFORMAT_INT, SAMPLEFORMAT_IEEEFP from tiff.h). Requires metadata to be read. */
     int sampleFormat() const;
-    /** @brief Get samples per pixel (e.g., 1 for grayscale, 3 for RGB). */
+    /** @brief Get samples per pixel (e.g., 1 for grayscale, 3 for RGB). Requires metadata to be read. */
     int samplesPerPixel() const;
 
-    /**
-     * @brief Get the raw data value interpreted as type T at a specific coordinate.
-     * Handles conversion based on stored metadata (bitsPerSample, sampleFormat).
-     * @warning Assumes T matches the data type or is convertible. Only reads first sample if SPP > 1.
-     * @param i X-coordinate (0 to width-1).
-     * @param j Y-coordinate (0 to height-1).
-     * @param k Z-coordinate (0 to depth-1).
-     * @return The raw data value interpreted as type T.
-     * @throws std::out_of_range if indices are out of bounds or data not read.
-     * @throws std::runtime_error if requested type T doesn't match data size.
-     */
-    // <<< FIX: Changed declaration to template >>>
-    template <typename T>
-    T getValue(int i, int j, int k) const;
-
-    /** @brief Get read-only access to the raw byte data vector. */
-    const std::vector<ByteType>& getRawData() const;
-
-    /** @brief Check if data has been successfully read. */
+    /** @brief Check if metadata has been successfully read and broadcast. */
     bool isRead() const { return m_is_read; }
 
 
 private:
-    /** @brief Internal implementation for reading ONE directory of the currently open TIFF. */
-    bool readTiffInternal(); // Assumes m_filename and tif handle are set by caller
-
     // --- Member Variables ---
-    std::string m_filename;             /**< Filename (or pattern) of the source */
-    std::vector<ByteType> m_raw_bytes;  /**< Vector containing the raw byte data */
-    int m_width = 0;                    /**< Width of the domain (X) */
-    int m_height = 0;                   /**< Height of the domain (Y) */
-    int m_depth = 0;                    /**< Depth of the domain (Z) */
-    bool m_is_read = false;             /**< Flag indicating if data has been successfully read */
+    // Source Info
+    std::string m_filename;         /**< Filename (single stack) */
+    std::string m_base_pattern;     /**< Base pattern for sequence */
+    std::string m_suffix;           /**< Suffix for sequence */
+    int m_start_index = 0;          /**< Starting index for sequence */
+    int m_digits = 1;               /**< Number of digits for sequence padding */
+    bool m_is_sequence = false;     /**< Flag indicating if source is a sequence */
 
-    // Metadata read from TIFF
-    uint16_t m_bits_per_sample = 0;     /**< TIFFTAG_BITSPERSAMPLE */
-    uint16_t m_sample_format = 0;       /**< TIFFTAG_SAMPLEFORMAT */
-    uint16_t m_samples_per_pixel = 0;   /**< TIFFTAG_SAMPLESPERPIXEL */
+    // Domain/Metadata Info (Read by Rank 0, Broadcast to all)
+    int m_width = 0;                /**< Width of the domain (X) */
+    int m_height = 0;               /**< Height of the domain (Y) */
+    int m_depth = 0;                /**< Depth of the domain (Z) */
+    bool m_is_read = false;         /**< Flag indicating if metadata has been successfully read and broadcast */
+
+    // TIFF Format Info (Read by Rank 0, Broadcast to all)
+    uint16_t m_bits_per_sample = 0; /**< TIFFTAG_BITSPERSAMPLE */
+    uint16_t m_sample_format = 0;   /**< TIFFTAG_SAMPLEFORMAT */
+    uint16_t m_samples_per_pixel = 0;/**< TIFFTAG_SAMPLESPERPIXEL */
+
+    // Private helper function implementing the core distributed read logic
+    // Called by the public threshold methods.
+    void readDistributedIntoFab(
+        amrex::iMultiFab& dest_mf,
+        int value_if_true,
+        int value_if_false,
+        double raw_threshold
+    ) const;
+
 
 }; // class TiffReader
 

--- a/src/io/tTiffReader.cpp
+++ b/src/io/tTiffReader.cpp
@@ -1,4 +1,4 @@
-#include "TiffReader.H" // Assuming defines OpenImpala::TiffReader
+#include "TiffReader.H" // Assuming defines OpenImpala::TiffReader and is updated
 
 #include <cstdlib>
 #include <string>
@@ -22,11 +22,12 @@
 #include <AMReX_CoordSys.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_PlotFileUtil.H>
-#include <AMReX_Utility.H>     // For amrex::UtilCreateDirectory
+#include <AMReX_Utility.H>      // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
 #include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
 
 // Default relative path to the sample TIFF file
+// *** Make sure this points to a valid TIFF file (Striped or Tiled) ***
 const std::string default_tiff_filename = "data/SampleData_2Phase.tif";
 // Output directory relative to executable location
 const std::string test_output_dir = "tTiffReader_output";
@@ -34,6 +35,15 @@ const std::string test_output_dir = "tTiffReader_output";
 const double default_threshold_value = 1.0;
 // Define Box size for breaking down domain
 const int BOX_SIZE = 32;
+
+// --- Optional: Add path for a Tiled TIFF for testing ---
+// const std::string default_tiled_tiff_filename = "data/SampleData_Tiled.tif";
+// --- Optional: Add path for a sequence ---
+// const std::string default_sequence_pattern = "data/seq/slice_";
+// const int default_sequence_num_files = 100;
+// const int default_sequence_digits = 4;
+// const std::string default_sequence_suffix = ".tif";
+
 
 int main (int argc, char* argv[])
 {
@@ -45,55 +55,79 @@ int main (int argc, char* argv[])
         std::string tiff_filename = default_tiff_filename;
         double threshold_val = default_threshold_value;
         bool write_plotfile = false; // Default: don't write plotfile
+        // --- Optional: Add flags for sequence/tiled tests ---
+        // bool test_sequence = false;
+        // bool test_tiled = false;
 
         { // Use ParmParse to read parameters from command line
-          // Example: ./executable tifffile=path/to/stack.tif threshold=128 write_plotfile=1
+         // Example: ./executable tifffile=path/to/stack.tif threshold=128 write_plotfile=1
             amrex::ParmParse pp;
             pp.query("tifffile", tiff_filename);
             pp.query("threshold", threshold_val);
             pp.query("write_plotfile", write_plotfile);
+            // --- Optional: Query flags for other tests ---
+            // pp.query("test_sequence", test_sequence);
+            // pp.query("test_tiled", test_tiled);
+            // if (test_tiled) tiff_filename = default_tiled_tiff_filename; // Example override
         }
 
         // Check if input file exists before attempting to read
+        // Note: For sequences, only check the first file
+        std::string file_to_check = tiff_filename;
+        // if (test_sequence) {
+        //     file_to_check = OpenImpala::generateFilename(default_sequence_pattern, default_start_index, default_sequence_digits, default_sequence_suffix);
+        // }
         {
-            std::ifstream test_ifs(tiff_filename);
+            std::ifstream test_ifs(file_to_check);
             if (!test_ifs) {
-                 amrex::Abort("Error: Cannot open input tifffile: " + tiff_filename + "\n"
-                              "       Specify path using 'tifffile=/path/to/file.tif'");
+                amrex::Abort("Error: Cannot open input file: " + file_to_check + "\n"
+                             "       Specify path using 'tifffile=/path/to/file.tif'");
             }
         }
 
         amrex::Print() << "Starting tTiffReader Test (Oxford, " << __DATE__ << " " << __TIME__ << ")\n";
-        amrex::Print() << "Input TIFF file: " << tiff_filename << "\n";
+        amrex::Print() << "Input TIFF source: " << tiff_filename << "\n"; // Adjust message if testing sequences
         amrex::Print() << "Threshold value: " << threshold_val << "\n";
         amrex::Print() << "Write plot file: " << (write_plotfile ? "Yes" : "No") << "\n";
 
         // --- Test TiffReader ---
         std::unique_ptr<OpenImpala::TiffReader> reader_ptr;
         // Expected properties for default SampleData_2Phase.tif
-        // **VERIFY THESE AGAINST YOUR ACTUAL SAMPLE FILE**
+        // ** VERIFY THESE AGAINST YOUR ACTUAL SAMPLE FILE **
+        // ** Also update if testing tiled or sequence files **
         int expected_width = 100;
         int expected_height = 100;
         int expected_depth = 100;
         int expected_bps = 8;       // e.g., 8-bit
-        int expected_format = 1;  // e.g., SAMPLEFORMAT_UINT from tiff.h
+        int expected_format = 1;    // e.g., SAMPLEFORMAT_UINT from tiff.h
         int expected_spp = 1;       // e.g., grayscale
 
         try {
-            // Assuming constructor reads file and throws std::runtime_error on failure
-            reader_ptr = std::make_unique<OpenImpala::TiffReader>(tiff_filename);
+            // *** BEHAVIOR CHANGE ***
+            // Constructor / readFile now reads METADATA only (Rank 0 + Broadcast)
+            // It does NOT load the pixel data into memory anymore.
+            amrex::Print() << "Creating TiffReader and reading metadata...\n";
 
-            // Alternative if using readFile pattern:
-            // reader_ptr = std::make_unique<OpenImpala::TiffReader>();
-            // if (!reader_ptr->readFile(tiff_filename)) {
-            //    throw std::runtime_error("Failed to read TIFF via readFile");
+            // --- Choose constructor based on test type ---
+            // if (test_sequence) {
+            //     reader_ptr = std::make_unique<OpenImpala::TiffReader>(
+            //         default_sequence_pattern, default_sequence_num_files,
+            //         default_start_index, default_sequence_digits, default_sequence_suffix);
+            //     expected_depth = default_sequence_num_files; // Update expected depth
+            //     // Update other expected values if sequence differs from single file
+            // } else {
+                 reader_ptr = std::make_unique<OpenImpala::TiffReader>(tiff_filename);
             // }
 
+            if (!reader_ptr->isRead()) { // Check if metadata read was successful
+                 throw std::runtime_error("Reader failed to read metadata (isRead() is false).");
+            }
+
         } catch (const std::exception& e) {
-            amrex::Abort("Error creating TiffReader: " + std::string(e.what()));
+            amrex::Abort("Error creating TiffReader or reading metadata: " + std::string(e.what()));
         }
 
-        // --- Check Dimensions & Metadata ---
+        // --- Check Dimensions & Metadata (Validates metadata read/broadcast) ---
         amrex::Print() << "Checking dimensions and metadata...\n";
         int actual_width = reader_ptr->width();
         int actual_height = reader_ptr->height();
@@ -107,33 +141,34 @@ int main (int argc, char* argv[])
 
         // Use if/Abort instead of assert for checks active in all builds
         if (actual_width != expected_width || actual_height != expected_height || actual_depth != expected_depth) {
-            amrex::Abort("FAIL: Read dimensions do not match expected dimensions (100x100x100).");
+            amrex::Abort("FAIL: Read dimensions do not match expected dimensions (" + std::to_string(expected_width) + "x" + std::to_string(expected_height) + "x" + std::to_string(expected_depth) +").");
         }
         if (actual_bps != expected_bps) {
              amrex::Abort("FAIL: Read BitsPerSample (" + std::to_string(actual_bps) +
-                         ") does not match expected value (" + std::to_string(expected_bps) + ").");
+                          ") does not match expected value (" + std::to_string(expected_bps) + ").");
         }
         if (actual_format != expected_format) {
              amrex::Abort("FAIL: Read SampleFormat (" + std::to_string(actual_format) +
-                         ") does not match expected value (" + std::to_string(expected_format) + ").");
+                          ") does not match expected value (" + std::to_string(expected_format) + ").");
         }
         if (actual_spp != expected_spp) {
              amrex::Abort("FAIL: Read SamplesPerPixel (" + std::to_string(actual_spp) +
-                         ") does not match expected value (" + std::to_string(expected_spp) + ").");
+                          ") does not match expected value (" + std::to_string(expected_spp) + ").");
         }
         amrex::Print() << "  Dimensions and basic metadata match expected values.\n";
-        // TODO: Add tests for TiffReader attribute reading if implemented.
-        // TODO: Add tests for TiffReader getValue(i,j,k) against known data points.
+        // TODO: Add tests for TiffReader attribute reading if implemented and needed.
+        // TODO: Add tests for TiffReader getValue(i,j,k) NO - getValue removed.
 
-        // --- Setup AMReX Data Structures ---
+        // --- Setup AMReX Data Structures (Remains the same) ---
         amrex::Geometry geom;
         amrex::Box domain_box = reader_ptr->box();
         if (domain_box.isEmpty()) {
-             amrex::Abort("FAIL: Reader returned an empty box.");
+             amrex::Abort("FAIL: Reader returned an empty box after metadata read.");
         }
         {
             amrex::RealBox rb({0.0, 0.0, 0.0}, {(amrex::Real)actual_width, (amrex::Real)actual_height, (amrex::Real)actual_depth}); // Physical domain matching pixel size
             amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0};
+            // Note: Using default CoodSys = 0 (Cartesian)
             amrex::Geometry::Setup(&rb, 0, is_periodic.data());
             geom.define(domain_box);
         }
@@ -142,15 +177,23 @@ int main (int argc, char* argv[])
         ba.maxSize(BOX_SIZE);
         amrex::DistributionMapping dm(ba);
         amrex::iMultiFab mf(ba, dm, 1, 0); // 1 component, 0 ghost cells
-        mf.setVal(0); // Initialize
+        mf.setVal(-1); // Initialize to a sentinel value (e.g., -1) to ensure threshold modifies it
 
-        // --- Test Thresholding ---
-        amrex::Print() << "Performing threshold > " << threshold_val << "...\n";
+        // --- Test Thresholding (Now performs distributed I/O + threshold) ---
+        amrex::Print() << "Performing threshold > " << threshold_val << " (This now reads data chunk-by-chunk)...\n";
         try {
-            // Use threshold(double, iMultiFab) overload for 1/0 output
+            // *** BEHAVIOR CHANGE ***
+            // This call now triggers the parallel, distributed reading of TIFF strips/tiles
+            // directly into the iMultiFab 'mf', applying the threshold during the read process.
             reader_ptr->threshold(threshold_val, mf);
+
+            // --- Optional: Test the other threshold overload ---
+            // mf.setVal(-1); // Reset sentinel
+            // reader_ptr->threshold(threshold_val, 100, 50, mf); // Test custom values
+            // Check min/max against 50/100
+
         } catch (const std::exception& e) {
-            amrex::Abort("Error during threshold operation: " + std::string(e.what()));
+            amrex::Abort("Error during threshold operation (read + process): " + std::string(e.what()));
         }
 
         // Check results (min/max across all processors)
@@ -160,8 +203,8 @@ int main (int argc, char* argv[])
         amrex::Print() << "  Threshold result min value: " << min_val << "\n";
         amrex::Print() << "  Threshold result max value: " << max_val << "\n";
 
-        // Check if result is binary (0 or 1)
-        // This check is valid only if the threshold value is expected to segment the data
+        // Check if result is binary (0 or 1) - Adjust if testing custom values
+        // This check is valid only if the threshold value is expected to segment the data into 0 and 1
         if (min_val < 0 || max_val > 1 || (min_val == 0 && max_val == 0) || (min_val == 1 && max_val == 1) ) {
              amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
                            << ") is not {0, 1}. Check threshold value ("<< threshold_val
@@ -169,55 +212,57 @@ int main (int argc, char* argv[])
              // If min==max==0 or min==max==1, threshold didn't separate phases.
              // Decide if this is a fatal error for the test.
              // amrex::Abort("FAIL: Threshold result unexpected.");
-        } else {
+        } else if (min_val == 0 && max_val == 1) {
              amrex::Print() << "  Threshold value range looks plausible (0 and 1 found).\n";
+        } else {
+             amrex::Print() << "  Threshold value range is [" << min_val << ", " << max_val << "]. Check threshold logic if 0/1 expected.\n";
         }
-        // TODO: Add tests for threshold overload with custom true/false values.
-        // TODO: Add separate tests for error conditions (bad file, unsupported TIFF format).
+        // TODO: Add separate tests for error conditions (bad file path handled, but test unsupported TIFF format if possible).
 
-        // --- Optional: Write Plotfile ---
+        // --- Optional: Write Plotfile (Remains the same) ---
         if (write_plotfile) {
             amrex::Print() << "Writing plot file...\n";
 
             // Create output directory relative to executable location
             if (amrex::ParallelDescriptor::IOProcessor()) {
-                 if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
-                      // Don't abort test, just warn that plotfile won't be written
-                      amrex::Warning("Could not create output directory: " + test_output_dir + ". Skipping plotfile write.");
-                      write_plotfile = false; // Disable writing
-                 }
+                if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
+                    // Don't abort test, just warn that plotfile won't be written
+                    amrex::Warning("Could not create output directory: " + test_output_dir + ". Skipping plotfile write.");
+                    write_plotfile = false; // Disable writing
+                }
             }
             // Barrier potentially needed if directory creation is slow on filesystem? Usually okay.
-            amrex::ParallelDescriptor::Barrier();
+            amrex::ParallelDescriptor::Barrier("PlotfileDirCreate");
 
             if (write_plotfile) // Check again in case directory creation failed
             {
-                // Get datetime string
+                // Get datetime string (same as before)
                 std::string datetime_str;
                 {
                     std::time_t strt_time; std::tm* timeinfo; char datetime_buf[80];
                     std::time(&strt_time); timeinfo = std::localtime(&strt_time);
-                    std::strftime(datetime_buf, sizeof(datetime_buf),"%Y%m%d%H%M",timeinfo);
+                    // Use ISO 8601 format for better sorting/clarity
+                    std::strftime(datetime_buf, sizeof(datetime_buf),"%Y%m%dT%H%M%S",timeinfo);
                     datetime_str = datetime_buf;
                 }
                 // Construct filename
                 std::string plotfilename = test_output_dir + "/tiffreadertest_" + datetime_str;
 
-                // Copy integer data to float MultiFab for plotting
+                // Copy integer data to float MultiFab for plotting (same as before)
                 amrex::MultiFab mfv(ba, dm, 1, 0);
                 // Use ParallelFor for the copy
                 for (amrex::MFIter mfi(mfv, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const amrex::Box& box = mfi.tilebox();
                     auto const& int_fab_arr = mf.const_array(mfi);
-                    auto       real_fab_arr = mfv.array(mfi);
+                    auto        real_fab_arr = mfv.array(mfi);
                     amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                     {
                         real_fab_arr(i, j, k) = static_cast<amrex::Real>(int_fab_arr(i, j, k));
                     });
                 }
 
-                // Write plot file
+                // Write plot file (same as before)
                 amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0, 0);
                 amrex::Print() << "  Plot file written to: " << plotfilename << "\n";
             }


### PR DESCRIPTION
## Refactor(IO): Overhaul TiffReader for Parallelism, Large Files, and Tiled Support


**Motivation:**

The previous `TiffReader` implementation had significant limitations for use in large-scale parallel simulations:
- It loaded the entire 3D dataset into memory (`m_raw_bytes`), making it unsuitable for datasets larger than available RAM on a single node.
- File reading was performed serially, creating an I/O bottleneck in parallel runs.
- It lacked support for Tiled TIFF files, a common format for large images.

This overhaul addresses these issues to provide a robust, scalable TIFF reader compatible with parallel AMReX applications, particularly for large CT or FIB-SEM datasets.

**Approach:**

This PR refactors the `TiffReader` following the scalable, chunked-reading pattern established by the `HDF5Reader`:

1.  **Separation of Concerns:** Metadata acquisition (dimensions, data type) is now performed first by MPI Rank 0 and broadcast to all ranks.
2.  **Distributed Chunked Reading:** Data reading is driven by `MFIter` over the target `amrex::iMultiFab`. Each rank reads only the necessary TIFF strips or tiles corresponding to its owned boxes.
3.  **Memory Scalability:** Data is read into small temporary buffers (strip/tile sized) and processed directly into the target `iMultiFab`, eliminating the need to store the entire dataset in memory.
4.  **Parallelism:** Leverages MPI for metadata distribution and distributing the reading workload across ranks. Uses OpenMP for potential intra-node parallelism during processing.
5.  **Tiled Support:** Added logic to handle Tiled TIFF files alongside Striped ones.

**Key Changes:**

* **`TiffReader.cpp`:**
    * Completely reimplemented the core data reading logic within a new private `readDistributedIntoFab` method (called by public `threshold` methods).
    * Refactored `readFile` and `readFileSequence` to handle metadata acquisition (Rank 0 + Broadcast) only.
    * Removed `m_raw_bytes`, `getValue`, `getRawData`, and `readTiffInternal`.
    * Implemented logic to handle both Striped (`TIFFReadEncodedStrip`) and Tiled (`TIFFReadEncodedTile`) formats.
    * Added helper function `interpretBytesAsDouble` for type conversion based on TIFF tags.
* **`TiffReader.h`:**
    * Updated the class interface to reflect the implementation changes.
    * Removed declarations for `m_raw_bytes`, `getRawData`, `getValue`, `readTiffInternal`.
    * Added private members for managing sequence parameters (`m_is_sequence`, etc.).
    * Updated documentation extensively (`@brief`, `@warning`, method docstrings) to describe the new parallel, scalable behavior and API usage.
* **`tTiffReader.cpp`:**
    * Adapted the test to work with the refactored reader. The call to `threshold()` now triggers the distributed I/O + processing.
    * Added comments explaining the change in reader behavior during construction (metadata only) and thresholding (read+process).
    * Improved verification slightly by initializing the target `iMultiFab`.
    * Added placeholders for future tests (e.g., sequences, specific tiled file validation).

**Benefits:**

* Enables reading of large TIFF files (including BigTIFF) that exceed single-node memory limits.
* Distributes the I/O workload across MPI ranks for improved parallel performance.
* Significantly reduces the memory footprint per rank.
* Adds support for reading Tiled TIFF files.

**Testing:**

The updated `tTiffReader` test verifies the core functionality by:
- Checking successful metadata read and broadcast.
- Calling the `threshold` method to perform the distributed read and processing into an `iMultiFab`.
- Verifying basic output properties (min/max values) of the resulting `iMultiFab`.
- Optionally writing an AMReX plotfile for visual inspection.

Further testing with dedicated large/tiled/sequence datasets is recommended.