### PR TITLE
Refactor(IO): Overhaul TiffReader for Scalability and Fix Related Tests/CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,12 +131,19 @@ jobs:
         continue-on-error: true # Keep this true
         run: |
           echo "Running make test..."
-          # Run tests, redirect stdout/stderr to log file
-          sudo apptainer exec \
+          # Add timeout (e.g., 1200 seconds = 20 minutes). Adjust time as needed.
+          # Run tests within timeout, redirect stdout/stderr to log file
+          timeout 1200 sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
             bash -c 'source /opt/rh/gcc-toolset-11/enable && cd /src && make test' > make_test_output.log 2>&1
           TEST_EXIT_CODE=$?
+          # Check if timeout occurred (exit code 124 for GNU timeout)
+          if [ $TEST_EXIT_CODE -eq 124 ]; then
+             echo "::error::Test step timed out after 20 minutes!"
+             # The job will fail later based on steps.make_test.outcome == 'failure' anyway,
+             # but this provides an explicit error message in the logs.
+          fi
           echo "Make test exit code: $TEST_EXIT_CODE"
 
           # --- Attempt to copy Backtrace files from container's /src to host's PWD ---
@@ -157,7 +164,7 @@ jobs:
 
       # Step 11: Upload Test Log and Backtrace <<< RENUMBERED (was Step 10)
       - name: Upload Test Log and Backtrace
-        # This step is only reached if the build (Step 7/9) succeeded
+        # This step runs even if make_test failed (due to continue-on-error), but only if build succeeded
         if: always() && steps.make_build.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
@@ -166,7 +173,7 @@ jobs:
             make_test_output.log
             Backtrace.*
           retention-days: 5
-          if-no-files-found: warn
+          if-no-files-found: warn # Use warn instead of error if no backtrace files found
 
       # Step 12: Explicitly fail the JOB if the make test step failed <<< RENUMBERED (was Step 11)
       - name: Check test outcome

--- a/src/props/tTortuosity.cpp
+++ b/src/props/tTortuosity.cpp
@@ -3,20 +3,21 @@
 #include "VolumeFraction.H"   // Assuming VolumeFraction is in OpenImpala namespace
 
 #include <AMReX.H>
-#include <AMReX_ParmParse.H>      // For reading parameters
-#include <AMReX_Utility.H>        // For amrex::UtilCreateDirectory
+#include <AMReX_ParmParse.H>       // For reading parameters
+#include <AMReX_Utility.H>         // For amrex::UtilCreateDirectory
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_Print.H>
+#include <AMReX_PlotFileUtil.H>    // Include for plotfile writing if enabled
 
-#include <cstdlib>     // For getenv
-#include <string>      // For std::string
-#include <stdexcept>   // For std::runtime_error (optional error handling)
-#include <cmath>       // For std::abs
-#include <limits>      // For numeric_limits
+#include <cstdlib>   // For getenv
+#include <string>    // For std::string
+#include <stdexcept> // For std::runtime_error (optional error handling)
+#include <cmath>     // For std::abs
+#include <limits>    // For numeric_limits
 
 // Helper function to convert string to Direction enum
 // (Assumes Direction enum exists in OpenImpala namespace)
@@ -62,7 +63,7 @@ int main (int argc, char* argv[])
         // --- Configuration via ParmParse ---
         std::string tifffile;
         std::string resultsdir;
-        int phase_id = 0;
+        int phase_id = 1; // Default phase ID to calculate tortuosity for (e.g., the conducting phase)
         std::string direction_str = "X";
         std::string solver_str = "GMRES";
         int box_size = 32;
@@ -71,23 +72,28 @@ int main (int argc, char* argv[])
         amrex::Real expected_vf = -1.0; // Use -1 to indicate not set
         amrex::Real expected_tau = -1.0;
         amrex::Real tolerance = 1e-9; // Default tolerance for comparisons
+        amrex::Real threshold_val = 0.5; // Default threshold for segmenting 0/1 data
 
         {
             amrex::ParmParse pp; // Default scope
-            pp.get("tifffile", tifffile); // Mandatory: Test file path
+            // Use get! Abort if tifffile is not provided in the inputs file.
+            pp.get("tifffile", tifffile);
 
             // Results directory: Try ParmParse first, then default to $HOME/openimpalaresults
             if (!pp.query("resultsdir", resultsdir)) {
                 const char* homeDir_cstr = getenv("HOME");
                 if (!homeDir_cstr) {
-                    amrex::Abort("Cannot determine results directory: 'resultsdir' not in inputs and $HOME not set.");
+                    amrex::Warning("Cannot determine default results directory: 'resultsdir' not in inputs and $HOME not set. Using './tortuosity_results'");
+                    resultsdir = "./tortuosity_results";
+                } else {
+                    std::string homeDir = homeDir_cstr;
+                    resultsdir = homeDir + "/openimpalaresults"; // Assumes Unix '/' separator
                 }
-                std::string homeDir = homeDir_cstr;
-                resultsdir = homeDir + "/openimpalaresults"; // Assumes Unix '/' separator
-                amrex::Print() << " Parameter 'resultsdir' not specified, using default: " << resultsdir << "\n";
+                 if(amrex::ParallelDescriptor::IOProcessor()) // Print only once
+                    amrex::Print() << " Parameter 'resultsdir' not specified, using default: " << resultsdir << "\n";
             }
 
-            pp.query("phase", phase_id);
+            pp.query("phase_id", phase_id); // Which phase ID to analyze (e.g., 1 after thresholding)
             pp.query("direction", direction_str);
             pp.query("solver", solver_str);
             pp.query("box_size", box_size);
@@ -96,25 +102,28 @@ int main (int argc, char* argv[])
             pp.query("expected_vf", expected_vf);
             pp.query("expected_tau", expected_tau);
             pp.query("tolerance", tolerance);
+            pp.query("threshold_val", threshold_val); // Allow overriding threshold value
         }
 
         // Convert string parameters to enums
         OpenImpala::Direction direction = stringToDirection(direction_str);
         OpenImpala::TortuosityHypre::SolverType solver_type = stringToSolverType(solver_str);
 
-        if (verbose > 0) {
+        // Print configuration (only Rank 0)
+        if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "\n--- Tortuosity Test Configuration ---\n";
-            amrex::Print() << " TIF File:           " << tifffile << "\n";
-            amrex::Print() << " Results Directory:  " << resultsdir << "\n";
-            amrex::Print() << " Phase ID:           " << phase_id << "\n";
-            amrex::Print() << " Direction:          " << direction_str << "\n";
-            amrex::Print() << " Solver:             " << solver_str << "\n";
-            amrex::Print() << " Box Size:           " << box_size << "\n";
-            amrex::Print() << " Verbose:            " << verbose << "\n";
-            amrex::Print() << " Write Plotfile:     " << write_plotfile << "\n";
-            amrex::Print() << " Tolerance:          " << tolerance << "\n";
-            if (expected_vf >= 0.0) amrex::Print() << " Expected VF:        " << expected_vf << "\n";
-            if (expected_tau >= 0.0) amrex::Print() << " Expected Tortuosity:" << expected_tau << "\n";
+            amrex::Print() << " TIF File:             " << tifffile << "\n";
+            amrex::Print() << " Results Directory:    " << resultsdir << "\n";
+            amrex::Print() << " Phase ID to Analyze:  " << phase_id << "\n";
+            amrex::Print() << " Threshold Value:      " << threshold_val << "\n";
+            amrex::Print() << " Direction:            " << direction_str << "\n";
+            amrex::Print() << " Solver:               " << solver_str << "\n";
+            amrex::Print() << " Box Size:             " << box_size << "\n";
+            amrex::Print() << " Verbose:              " << verbose << "\n";
+            amrex::Print() << " Write Plotfile:       " << write_plotfile << "\n";
+            amrex::Print() << " Comparison Tolerance: " << tolerance << "\n";
+            if (expected_vf >= 0.0) amrex::Print() << " Expected VF:          " << expected_vf << "\n";
+            if (expected_tau >= 0.0) amrex::Print() << " Expected Tortuosity:  " << expected_tau << "\n";
             amrex::Print() << "------------------------------------\n\n";
         }
 
@@ -124,21 +133,26 @@ int main (int argc, char* argv[])
         amrex::DistributionMapping dm;
         amrex::iMultiFab mf_phase; // Phase data MultiFab
 
-        // --- Read TIFF and Setup Grids/Geometry ---
+        // --- Read TIFF Metadata and Setup Grids/Geometry ---
         try {
-            // Limit TiffReader scope to release memory early
-            if (verbose > 0) amrex::Print() << " Reading file " << tifffile << "...\n";
+            // Read metadata only first
+            if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Reading metadata from " << tifffile << "...\n";
+            // TiffReader constructor reads metadata via Rank 0 + Bcast
             OpenImpala::TiffReader reader(tifffile);
+            if (!reader.isRead()) {
+                 throw std::runtime_error("Reader failed to read metadata (isRead() is false).");
+            }
 
             const amrex::Box domain_box = reader.box();
+            if (domain_box.isEmpty()) {
+                throw std::runtime_error("Reader returned an empty domain box after metadata read.");
+            }
 
-            // Define physical domain size - using simple {0,0,0} to {Lx,Ly,Lz}
-            // Assumes voxel size is implicitly 1 unit. Adjust if voxel size is known.
+            // Define physical domain size
             amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
                               {AMREX_D_DECL(amrex::Real(domain_box.length(0)),
                                             amrex::Real(domain_box.length(1)),
                                             amrex::Real(domain_box.length(2)))});
-
             amrex::Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)}; // Non-periodic
             geom.define(domain_box, &rb, 0, is_periodic.data());
 
@@ -149,80 +163,119 @@ int main (int argc, char* argv[])
 
             // Define the phase MultiFab with 1 component and 1 ghost cell layer
             mf_phase.define(ba, dm, 1, 1);
+            mf_phase.setVal(-1); // Initialize with sentinel value
 
-            // Read/threshold phase data into the valid regions of mf_phase
-            if (verbose > 0) amrex::Print() << " Thresholding phase data for phase " << phase_id << "...\n";
-            reader.threshold(phase_id, mf_phase); // Assuming this puts 1 for phase_id, 0 otherwise? Or phase IDs directly? Adjust VF/Tortuosity phase param accordingly.
-                                                  // Let's assume it fills with actual phase IDs from file.
+            // *** Corrected Thresholding Call ***
+            // Use the threshold value to segment the data into phases 0 and 1.
+            // Assumes phase '1' is the target phase if pixel > threshold_val.
+            if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                 amrex::Print() << " Thresholding data (Phase=1 if > " << threshold_val << ", else 0)...\n";
+            }
+            reader.threshold(threshold_val, 1, 0, mf_phase); // Output 1 if > thresh, else 0
+
+            // *** Verification Step for Phase Field ***
+            int min_phase = mf_phase.min(0); // Component 0
+            int max_phase = mf_phase.max(0);
+             if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                 amrex::Print() << "  Phase field min/max after thresholding: " << min_phase << " / " << max_phase << "\n";
+             }
+            // If min == max, the thresholding likely failed to segment the phases,
+            // which will cause problems for the tortuosity calculation.
+            if (min_phase == max_phase) {
+                amrex::Abort("FAIL: Phase field (mf_phase) is uniform after thresholding! Check threshold value ("
+                             + std::to_string(threshold_val) + ") and input TIFF data range.");
+            }
+            // Check if the target phase_id actually exists in the thresholded data
+            bool target_phase_present = (phase_id == min_phase || phase_id == max_phase);
+            if (!target_phase_present && amrex::ParallelDescriptor::IOProcessor()) {
+                 amrex::Warning("Target phase_id " + std::to_string(phase_id) + " not found in thresholded data range ["
+                                + std::to_string(min_phase) + ", " + std::to_string(max_phase) + "]. Tortuosity might be ill-defined.");
+                 // Don't necessarily abort, maybe VF calculation handles this, but warn.
+            }
+
 
             // Fill ghost cells based on neighboring valid data
             mf_phase.FillBoundary(geom.periodicity());
 
-            if (verbose > 0) amrex::Print() << " Grid and phase data setup complete.\n";
+            if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Grid and phase data setup complete.\n";
 
         } catch (const std::exception& e) {
             amrex::Abort("Error during TiffReader processing or grid setup: " + std::string(e.what()));
         }
 
         // --- Calculate and Verify Volume Fraction ---
-        if (verbose > 0) amrex::Print() << " Calculating Volume Fraction for phase " << phase_id << "...\n";
-        OpenImpala::VolumeFraction vf(mf_phase, phase_id); // Assumes VF calculates for phase `phase_id` vs others. Check component index if needed.
+        if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculating Volume Fraction for phase " << phase_id << "...\n";
+        // VolumeFraction constructor likely takes the iMultiFab and the target phase ID
+        OpenImpala::VolumeFraction vf(mf_phase, phase_id);
         amrex::Real actual_vf = vf.value(false); // Get global value
 
-        amrex::Print() << " Calculated Volume Fraction: " << actual_vf << "\n";
+        if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculated Volume Fraction: " << actual_vf << "\n";
         if (expected_vf >= 0.0) { // Check only if an expected value was provided
-            amrex::Print() << " Expected Volume Fraction:   " << expected_vf << "\n";
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Expected Volume Fraction:   " << expected_vf << "\n";
             if (std::abs(actual_vf - expected_vf) > tolerance) {
                 amrex::Abort("FAIL: Volume Fraction mismatch. Diff: " + std::to_string(std::abs(actual_vf - expected_vf)));
             }
-             amrex::Print() << " Volume Fraction Check:      PASS\n";
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Volume Fraction Check:    PASS\n";
         } else {
-             amrex::Print() << " Volume Fraction Check:      SKIPPED (no expected value provided)\n";
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Volume Fraction Check:    SKIPPED (no expected value provided)\n";
         }
+         if (actual_vf <= 0.0) {
+              if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Warning: Volume fraction for target phase " << phase_id << " is zero or negative. Tortuosity is ill-defined." << std::endl;
+              // Depending on expected behavior, could abort or just expect NaN/Inf tortuosity
+         }
 
 
         // --- Calculate and Verify Tortuosity ---
 
-        // Ensure results directory exists
-        if (!amrex::UtilCreateDirectory(resultsdir, 0755)) {
-            amrex::Warning("Could not create results directory: " + resultsdir);
-            // Depending on TortuosityHypre implementation, this might be non-fatal if plotfiles are disabled
+        // Ensure results directory exists (only IOProcessor needs to create)
+        if (!resultsdir.empty() && amrex::ParallelDescriptor::IOProcessor()) {
+            if (!amrex::UtilCreateDirectory(resultsdir, 0755)) {
+                amrex::Warning("Could not create results directory: " + resultsdir);
+                // Proceed, but plotfile writing in TortuosityHypre might fail
+            }
+        }
+        amrex::ParallelDescriptor::Barrier(); // Ensure directory exists before others proceed
+
+        amrex::Real actual_tau = std::numeric_limits<amrex::Real>::quiet_NaN();
+        if (actual_vf > 0.0) // Only calculate if volume fraction is non-zero
+        {
+            if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculating Tortuosity for phase " << phase_id << " in direction " << direction_str << " using " << solver_str << "...\n";
+
+            // Create Tortuosity object
+            // Adjust parameters based on the actual TortuosityHypre constructor signature.
+            // Pass the verbose level from this test down to the class.
+            OpenImpala::TortuosityHypre tortuosity(geom, ba, dm, mf_phase, actual_vf, phase_id, direction, solver_type, resultsdir, 1.0, 0.0, verbose); // Default Vhi=1, Vlo=0
+
+            actual_tau = tortuosity.value(); // Calculate tortuosity
+        } else {
+             if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Skipping Tortuosity calculation because Volume Fraction is zero.\n";
+             // Leave actual_tau as NaN or set to a specific value like 0 or Inf? Depends on definition.
         }
 
-        if (verbose > 0) amrex::Print() << " Calculating Tortuosity for phase " << phase_id << " in direction " << direction_str << " using " << solver_str << "...\n";
 
-        // Create Tortuosity object
-        // Note: Assumes TortuosityHypre constructor takes: geom, ba, dm, phase_mf, vf_value, phase_id, direction, solver_type, results_dir, [optional: plot_flag]
-        // Adjust parameters based on the actual TortuosityHypre constructor signature.
-        OpenImpala::TortuosityHypre tortuosity(geom, ba, dm, mf_phase, actual_vf, phase_id, direction, solver_type, resultsdir /*, maybe write_plotfile flag? */);
-
-        amrex::Real actual_tau = tortuosity.value(); // Calculate tortuosity
-
-        amrex::Print() << " Calculated Tortuosity:      " << actual_tau << "\n";
+        if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculated Tortuosity:    " << actual_tau << "\n";
         if (expected_tau >= 0.0) { // Check only if an expected value was provided
-             amrex::Print() << " Expected Tortuosity:      " << expected_tau << "\n";
-            if (!std::isnan(actual_tau) && !std::isinf(actual_tau) && // Check for valid number before comparison
-                 std::abs(actual_tau - expected_tau) > tolerance) {
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Expected Tortuosity:    " << expected_tau << "\n";
+            // Check for valid number before comparison
+            bool actual_is_invalid = std::isnan(actual_tau) || std::isinf(actual_tau);
+            bool expected_is_invalid = std::isnan(expected_tau) || std::isinf(expected_tau);
+
+            if (actual_is_invalid != expected_is_invalid) {
+                 amrex::Abort("FAIL: Tortuosity mismatch. One value is finite, the other is NaN/Inf.");
+            } else if (!actual_is_invalid && std::abs(actual_tau - expected_tau) > tolerance) {
                  amrex::Abort("FAIL: Tortuosity mismatch. Diff: " + std::to_string(std::abs(actual_tau - expected_tau)));
-             }
-             // Handle expected NaN/Inf cases if necessary for specific tests
-             else if ((std::isnan(actual_tau) || std::isinf(actual_tau)) && !(std::isnan(expected_tau) || std::isinf(expected_tau))) {
-                 amrex::Abort("FAIL: Tortuosity mismatch. Calculated NaN/Inf, expected finite.");
-             }
-             else if (!(std::isnan(actual_tau) || std::isinf(actual_tau)) && (std::isnan(expected_tau) || std::isinf(expected_tau))) {
-                 amrex::Abort("FAIL: Tortuosity mismatch. Calculated finite, expected NaN/Inf.");
-             }
-             amrex::Print() << " Tortuosity Check:         PASS\n";
+            }
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Tortuosity Check:         PASS\n";
         } else {
-             amrex::Print() << " Tortuosity Check:         SKIPPED (no expected value provided)\n";
+             if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Tortuosity Check:         SKIPPED (no expected value provided)\n";
         }
 
         // --- Success & Timing ---
-        amrex::Print() << "\n Test Completed Successfully.\n";
+        if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "\n Test Completed Successfully.\n";
 
         amrex::Real stop_time = amrex::second() - strt_time;
         amrex::ParallelDescriptor::ReduceRealMax(stop_time, amrex::ParallelDescriptor::IOProcessorNumber());
-        amrex::Print() << " Run time = " << stop_time << " sec\n";
+        if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Run time = " << stop_time << " sec\n";
 
     } // End of scope for AMReX objects
     amrex::Finalize();

--- a/tests/inputs/tTortuosity.inputs
+++ b/tests/inputs/tTortuosity.inputs
@@ -1,15 +1,31 @@
 # Input file for tTortuosity test
 
 # Path to the input image file used to define the geometry/phases.
-# Based on other tests, using the sample TIFF file. Adjust if needed.
 tifffile = data/SampleData_2Phase.tif
 
-# --- Add other parameters required specifically by tTortuosity below ---
-# Example parameters (uncomment and adjust as needed):
-#
-# phase_id = 1             # ID of the phase to calculate tortuosity for
-# direction = 0            # 0=X, 1=Y, 2=Z
-# solver_type = hypre      # Or 'direct'
-# output_file = tort.txt   # Optional output file
-# hypre.max_iter = 200     # Example solver parameter
-# hypre.tolerance = 1e-9   # Example solver parameter
+# --- Tortuosity specific parameters ---
+
+# Set these explicitly based on your test case needs.
+# Examples:
+# phase_id = 1             # ID of the phase to calculate tortuosity for (MUST BE SET if not default in C++)
+# direction = 0            # 0=X, 1=Y, 2=Z (MUST BE SET if not default in C++)
+# solver_type = GMRES      # Solver type (e.g., GMRES, PCG, FlexGMRES, Jacobi)
+
+# --- Solver Controls (Crucial for Debugging/Testing) ---
+# Reduce iterations and loosen tolerance to check for hangs/slowness quickly.
+# Increase maxiter and tighten eps for production runs or accuracy tests.
+hypre.maxiter = 50      # Max solver iterations (Reduced for faster testing/debugging hangs)
+hypre.eps = 1e-6        # Solver relative tolerance (Loosened for faster testing)
+
+# --- Test Verbosity ---
+# Increase verbosity for more detailed output during test run.
+# Assumes TortuosityHypre class checks this value.
+verbose = 2
+
+# Optional output file (usually not needed for automated tests)
+# output_file = tort.txt
+
+# Expected values for verification (Optional - set if known for the sample data)
+# expected_vf = 0.5
+# expected_tau = 2.0
+# tolerance = 1e-6      # Tolerance for comparing expected vs actual values


### PR DESCRIPTION
## Refactor(IO): Overhaul TiffReader for Scalability and Fix Related Tests/CI

**Motivation:**

This PR addresses significant limitations in the previous `TiffReader` implementation, which was unsuitable for large datasets commonly encountered in simulations (e.g., CT/FIB-SEM data) and inefficient in parallel environments. The original reader loaded entire files into memory, lacked Tiled TIFF support, and performed I/O serially. This overhaul aims to provide a robust, memory-scalable, and parallel-capable TIFF reader integrated with AMReX.

**Summary of Changes:**

1.  **`TiffReader` Refactoring (`TiffReader.h`, `TiffReader.cpp`):**
    * **Parallel & Scalable Design:** Rewrote the core reading logic to mirror the `HDF5Reader` pattern. Metadata is read by Rank 0 and broadcast. Data reading uses `MFIter` to iterate over the target `iMultiFab`, with each rank reading only the necessary TIFF strips or tiles into small temporary buffers.
    * **Memory Efficiency:** Eliminated the `m_raw_bytes` member, preventing full dataset allocation and allowing processing of files larger than single-node RAM.
    * **Tiled TIFF Support:** Added logic to detect and read Tiled TIFF files using `TIFFIsTiled`, `TIFFReadEncodedTile`, etc., alongside existing Striped support.
    * **1-bit TIFF Support:** Implemented specific logic to handle 1-bit-per-sample TIFF files, including correct byte/bit index calculations and bit extraction.
    * **BigTIFF Ready:** The scalable memory design combined with LibTIFF >= 4.0 enables handling of BigTIFF files.
    * **Bug Fixes:** Corrected compilation errors related to `std::string` broadcasting (`Bcast`), `Array4` access, a missing `threshold` overload definition (linker error), and runtime errors (segfault/corruption) by fixing `TIFFComputeTile` parameters and adding buffer bounds checks.

2.  **`TortuosityHypre.cpp` Enhancements:**
    * **Verbose Logging:** Added `amrex::Print` statements controlled by the `verbose` parameter at key stages (setup, solve entry/exit) to aid debugging.
    * **Solver Iteration Logging:** Enabled HYPRE's internal solver logging (`HYPRE_StructXXXSetLogging`) when `verbose > 1` to monitor convergence progress.

3.  **Test Suite Updates (`tTortuosity.cpp`, `tTiffReader.cpp`, new input file):**
    * **`tests/inputs/tTortuosity.inputs`:** Added this previously missing file, providing the required `tifffile` parameter and adding controls for `hypre.maxiter`, `hypre.eps`, and `verbose` to aid debugging the tortuosity calculation.
    * **`tTortuosity.cpp`:**
        * Corrected the call to `TiffReader::threshold` to use a midpoint value (e.g., 0.5) for segmenting input phase data, rather than incorrectly using the target `phase_id` as the threshold.
        * Added verification check (min/max) on the `mf_phase` MultiFab after thresholding to ensure segmentation occurred and wasn't uniform.
        * Added check to skip tortuosity calculation if the target phase volume fraction is zero.
    * **`tTiffReader.cpp`:** Updated the expected `BitsPerSample` value from 8 to 1 to match the actual sample data file (`data/SampleData_2Phase.tif`), resolving a test assertion failure.

4.  **CI Workflow Update (`build-test.yml`):**
    * **Timeout:** Added the `timeout` command (set to 20 minutes) to the `make test` execution step. This prevents potential hangs (especially in `tTortuosity`) from blocking the CI workflow indefinitely and provides clearer failure feedback.

**Outcome:**

These changes deliver a significantly improved `TiffReader` suitable for parallel, large-scale simulations. The associated test suite updates ensure the new reader is tested more correctly and provide better tools for diagnosing issues with computationally intensive tests like `tTortuosity`. The CI workflow is now more robust against test hangs.