### PR TITLE
Fix TortuosityHypre Build Error and Add HYPRE Debugging

### DIFF
--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -50,10 +50,10 @@ public:
 
     /** @brief Specifies the HYPRE structured solver algorithm to use. */
     enum class SolverType {
-        Jacobi,     /**< HYPRE_StructJacobi */
-        GMRES,      /**< HYPRE_StructGMRES */
-        FlexGMRES,  /**< HYPRE_StructFlexGMRES */
-        PCG         /**< HYPRE_StructPCG (Added as a common alternative) */
+        Jacobi,      /**< HYPRE_StructJacobi */
+        GMRES,       /**< HYPRE_StructGMRES */
+        FlexGMRES,   /**< HYPRE_StructFlexGMRES */
+        PCG          /**< HYPRE_StructPCG (Added as a common alternative) */
         // Add others like BiCGSTAB if needed
     };
 
@@ -75,6 +75,7 @@ public:
      * @param vlo The potential value applied at the low boundary in the specified direction.
      * @param vhi The potential value applied at the high boundary in the specified direction.
      * @param verbose Verbosity level (0 = minimal, higher values for more output).
+     * @param write_plotfile If true, write a plotfile of the solution. (<<< ADDED PARAMETER)
      */
     TortuosityHypre(const amrex::Geometry& geom,
                     const amrex::BoxArray& ba,
@@ -87,7 +88,8 @@ public:
                     const std::string& resultspath,
                     const amrex::Real vlo = 0.0, // Default BC values if often used
                     const amrex::Real vhi = 1.0,
-                    int verbose = 0);
+                    int verbose = 0,
+                    bool write_plotfile = false); // <<< ADDED PARAMETER with default
 
     /** Destructor. Cleans up allocated HYPRE resources. */
     virtual ~TortuosityHypre() override;
@@ -202,34 +204,35 @@ private:
     // --- Member Variables ---
 
     // Configuration (set at construction)
-    const SolverType m_solvertype;       /**< HYPRE solver algorithm to use. */
-    std::string m_resultspath;           /**< Base path for results output. */
-    const int m_phase;                   /**< Index of the phase of interest. */
-    const OpenImpala::Direction m_dir;   /**< Principal direction of flow/gradient. */
-    const amrex::Real m_vlo;             /**< Potential value at low boundary in m_dir. */
-    const amrex::Real m_vhi;             /**< Potential value at high boundary in m_dir. */
-    amrex::Real m_eps = 1e-7;            /**< Solver relative convergence tolerance. */
-    int m_maxiter = 50000;               /**< Solver maximum iterations. */
-    int m_verbose = 0;                   /**< Verbosity level. */
-    amrex::Real m_vf;                    /**< Volume Fraction (stored by value). */
+    const SolverType m_solvertype;      /**< HYPRE solver algorithm to use. */
+    std::string m_resultspath;          /**< Base path for results output. */
+    const int m_phase;                  /**< Index of the phase of interest. */
+    const OpenImpala::Direction m_dir;  /**< Principal direction of flow/gradient. */
+    const amrex::Real m_vlo;            /**< Potential value at low boundary in m_dir. */
+    const amrex::Real m_vhi;            /**< Potential value at high boundary in m_dir. */
+    amrex::Real m_eps = 1e-7;           /**< Solver relative convergence tolerance. */
+    int m_maxiter = 50000;              /**< Solver maximum iterations. */
+    int m_verbose = 0;                  /**< Verbosity level. */
+    amrex::Real m_vf;                   /**< Volume Fraction (stored by value). */
+    bool m_write_plotfile;              /**< Flag to control plotfile writing (<<< ADDED MEMBER) */
 
     // AMReX Geometry & Data (references + owned copies/results)
-    const amrex::Geometry& m_geom;       /**< Domain geometry (reference, lifetime managed externally). */
-    const amrex::BoxArray& m_ba;         /**< Box layout (reference, lifetime managed externally). */
+    const amrex::Geometry& m_geom;      /**< Domain geometry (reference, lifetime managed externally). */
+    const amrex::BoxArray& m_ba;        /**< Box layout (reference, lifetime managed externally). */
     const amrex::DistributionMapping& m_dm; /**< Box distribution (reference, lifetime managed externally). */
-    amrex::iMultiFab m_mf_phase;         /**< Phase data (owned copy, potentially preconditioned). */
-    amrex::MultiFab m_mf_phi;            /**< Potential field solution (owned). */
+    amrex::iMultiFab m_mf_phase;        /**< Phase data (owned copy, potentially preconditioned). */
+    amrex::MultiFab m_mf_phi;           /**< Potential field solution (owned). */
 
     // State Variables
     amrex::Real m_value = std::numeric_limits<amrex::Real>::quiet_NaN(); /**< Cached tortuosity value. */
-    bool m_first_call = true;            /**< Flag to trigger solve() on first call to value(). */
+    bool m_first_call = true;           /**< Flag to trigger solve() on first call to value(). */
 
     // HYPRE Data Structures (managed internally)
-    HYPRE_StructGrid m_grid = NULL;      /**< HYPRE grid object. */
+    HYPRE_StructGrid m_grid = NULL;     /**< HYPRE grid object. */
     HYPRE_StructStencil m_stencil = NULL;/**< HYPRE stencil object. */
-    HYPRE_StructMatrix m_A = NULL;       /**< HYPRE matrix object (Laplacian). */
-    HYPRE_StructVector m_b = NULL;       /**< HYPRE RHS vector object. */
-    HYPRE_StructVector m_x = NULL;       /**< HYPRE solution vector object. */
+    HYPRE_StructMatrix m_A = NULL;      /**< HYPRE matrix object (Laplacian). */
+    HYPRE_StructVector m_b = NULL;      /**< HYPRE RHS vector object. */
+    HYPRE_StructVector m_x = NULL;      /**< HYPRE solution vector object. */
 };
 
 } // namespace OpenImpala


### PR DESCRIPTION
This PR addresses two issues encountered in the CI pipeline related to the `TortuosityHypre` class:

1.  **Fixes Compilation Error:** Resolves a build failure caused by the `write_plotfile` variable being used in `TortuosityHypre::solve()` without being declared in the class scope.
    * Added `bool m_write_plotfile` member to `TortuosityHypre.H`.
    * Added corresponding `bool write_plotfile` parameter to the `TortuosityHypre` constructor in `.H` and `.cpp`.
    * Updated call sites in `tTortuosity.cpp` and `Diffusion.cpp` to pass the flag to the constructor.

2.  **Adds HYPRE Debug Diagnostics:** Includes checks in `TortuosityHypre::setupMatrixEquation()` to help diagnose the runtime HYPRE error (`HYPRE_ERROR_GENERIC`) previously observed during `HYPRE_StructVectorSetBoxValues(m_b, ...)`:
    * Added a check to ensure the `m_b` vector handle is not NULL after initialization.
    * Added an `amrex::Print` statement to output the specific `Box` being processed just before the potentially failing HYPRE call.
    * Includes the previously added (but ultimately passing) check for NaN/Inf values in the `rhs_values` array returned by Fortran.

**Additional Changes:**

* Fixed a `-Wsign-compare` compiler warning in the NaN/Inf debug loop.
* Tidied up historical comments in `Diffusion.cpp`.

These changes aim to resolve the build failure and provide more information in the CI logs if the runtime HYPRE error persists.