### PR TITLE
Debug: Add standalone Hypre test for StructMatrixCreate issue

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,6 +117,75 @@ jobs:
           path: dependency_image.sif
           key: ${{ runner.os }}-apptainer-sif-${{ hashFiles('containers/Singularity.deps.def') }}
 
+      
+      # Step 6.1: Verify hypre_test.cpp exists in src/props/
+      - name: Verify hypre_test.cpp exists
+        id: check_hypre_test_file
+        run: |
+          # Check relative to the repository root ($PWD in the runner)
+          if [ ! -f ./src/props/hypre_test.cpp ]; then
+            echo "::error::Standalone test file ./src/props/hypre_test.cpp not found!"
+            exit 1
+          else
+            echo "Standalone test file ./src/props/hypre_test.cpp found."
+          fi
+
+      # Step 6.2: Compile Standalone HYPRE Test inside Container
+      - name: Compile Standalone HYPRE Test
+        id: compile_hypre_test
+        # Run only if the test file exists
+        if: steps.check_hypre_test_file.outcome == 'success'
+        run: |
+          echo "Compiling hypre_test.cpp inside container..."
+          # Execute compile command inside the container
+          # Use mpic++ for C++ file
+          # The source file path is now relative to the /src mount point inside the container
+          sudo apptainer exec \
+            --bind $PWD:/src \
+            ./dependency_image.sif \
+            bash -c 'source /opt/rh/gcc-toolset-11/enable && \
+                     cd /src && \
+                     echo "Running: mpic++ src/props/hypre_test.cpp -o hypre_test -I/opt/hypre/v2.32.0/include -L/opt/hypre/v2.32.0/lib -lHYPRE -fopenmp -lm" && \
+                     mpic++ src/props/hypre_test.cpp -o hypre_test -I/opt/hypre/v2.32.0/include -L/opt/hypre/v2.32.0/lib -lHYPRE -fopenmp -lm' > compile_hypre_test.log 2>&1
+          COMPILE_EXIT_CODE=$?
+          cat compile_hypre_test.log # Print compile output
+          if [ $COMPILE_EXIT_CODE -ne 0 ]; then
+            echo "::error::Standalone HYPRE test compilation failed! Exit code: $COMPILE_EXIT_CODE"
+            exit $COMPILE_EXIT_CODE
+          fi
+          echo "Standalone HYPRE test compilation successful."
+          # The executable 'hypre_test' will be created in /src (which is $PWD on the host)
+          ls -l ./hypre_test # Verify executable exists
+
+      # Step 6.3: Run Standalone HYPRE Test inside Container
+      - name: Run Standalone HYPRE Test
+        id: run_hypre_test
+        # Run only if compilation succeeded
+        if: steps.compile_hypre_test.outcome == 'success'
+        run: |
+          echo "Running hypre_test inside container..."
+          # Execute run command inside the container
+          # The executable path is relative to the /src mount point
+          sudo apptainer exec \
+            --bind $PWD:/src \
+            ./dependency_image.sif \
+            bash -c 'source /opt/rh/gcc-toolset-11/enable && \
+                     cd /src && \
+                     echo "Running: mpirun -np 1 --allow-run-as-root ./hypre_test" && \
+                     mpirun -np 1 --allow-run-as-root ./hypre_test' > run_hypre_test.log 2>&1
+          RUN_EXIT_CODE=$?
+          cat run_hypre_test.log # Print runtime output
+          if [ $RUN_EXIT_CODE -ne 0 ]; then
+            echo "::error::Standalone HYPRE test execution failed! Exit code: $RUN_EXIT_CODE"
+            # Decide if this failure should stop the whole workflow
+            # exit $RUN_EXIT_CODE
+            echo "::warning::Standalone HYPRE test failed, but continuing workflow..." # Example: Warn but continue
+          fi
+          echo "Standalone HYPRE test execution finished."
+          # Optional: Upload logs as artifacts if needed
+          # actions/upload-artifact@v4 ... with path: compile_hypre_test.log, run_hypre_test.log
+
+
       # Step 7: Build OpenImpala using Dependency SIF
       - name: Build OpenImpala using Dependency SIF
         id: make_build

--- a/src/props/hypre_test.cpp
+++ b/src/props/hypre_test.cpp
@@ -1,0 +1,120 @@
+#include <mpi.h>
+#include <HYPRE.h>
+#include <HYPRE_struct_ls.h> // For Struct interface
+#include <HYPRE_struct_mv.h> // For Struct interface
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Simple HYPRE error checking macro
+#define HYPRE_CHECK_MSG(msg, ierr) do { \
+    if (ierr != 0) { \
+        char hypre_error_msg[256]; \
+        HYPRE_DescribeError(ierr, hypre_error_msg); \
+        fprintf(stderr, "FAIL: %s\n", msg); \
+        fprintf(stderr, "  HYPRE Error: %s (Code: %d)\n", hypre_error_msg, ierr); \
+        MPI_Abort(MPI_COMM_WORLD, ierr); \
+    } else { \
+        printf("PASS: %s\n", msg); \
+    } \
+} while (0)
+
+int main(int argc, char *argv[]) {
+    int myid, num_procs;
+    int ierr = 0;
+
+    // Initialize MPI
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+
+    if (myid == 0) {
+        printf("Running HYPRE Standalone Test (hypre_test.cpp)...\n");
+        printf("MPI Procs: %d\n", num_procs);
+        // Note: This test is designed for -np 1, but should technically work for more.
+        if (num_procs > 1) {
+             printf("WARNING: This test is primarily designed for 1 MPI process.\n");
+        }
+    }
+
+    // Initialize HYPRE
+    // Using HYPRE_Init() is generally preferred over the old HYPRE_Init(&argc, &argv)
+    ierr = HYPRE_Init();
+    HYPRE_CHECK_MSG("HYPRE_Init", ierr);
+
+    // 1. Set up Grid
+    HYPRE_StructGrid grid;
+    const int ndim = 3;
+    ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, ndim, &grid);
+    HYPRE_CHECK_MSG("HYPRE_StructGridCreate", ierr);
+
+    // Define the grid extents for this process (simple 10x10x10 box on rank 0)
+    // Assumes running with -np 1 for simplicity, so rank 0 owns the whole box.
+    // If running with more procs, this part would need proper decomposition.
+    HYPRE_Int ilower[ndim] = {0, 0, 0};
+    HYPRE_Int iupper[ndim] = {9, 9, 9}; // 10 points in each dim: 0..9
+
+    if (myid == 0) { // Only rank 0 sets extents in this simple -np 1 case
+         printf("  Setting grid extents: [%d,%d,%d] to [%d,%d,%d]\n",
+               ilower[0], ilower[1], ilower[2], iupper[0], iupper[1], iupper[2]);
+        ierr = HYPRE_StructGridSetExtents(grid, ilower, iupper);
+        HYPRE_CHECK_MSG("HYPRE_StructGridSetExtents", ierr);
+    }
+    // In a multi-process run, other ranks would set their extents here.
+    // Barrier to ensure all ranks have potentially set extents before assembling.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+
+    // Assemble the grid
+    ierr = HYPRE_StructGridAssemble(grid);
+    HYPRE_CHECK_MSG("HYPRE_StructGridAssemble", ierr);
+    printf("  Grid assembled successfully.\n");
+
+    // 2. Set up Stencil (1-point)
+    HYPRE_StructStencil stencil;
+    const int stencil_size = 1;
+    ierr = HYPRE_StructStencilCreate(ndim, stencil_size, &stencil);
+    HYPRE_CHECK_MSG("HYPRE_StructStencilCreate", ierr);
+
+    HYPRE_Int offsets[stencil_size][ndim] = {{0, 0, 0}}; // Center point only
+    for (int j = 0; j < stencil_size; ++j) {
+        ierr = HYPRE_StructStencilSetElement(stencil, j, offsets[j]);
+        HYPRE_CHECK_MSG("HYPRE_StructStencilSetElement", ierr);
+    }
+    printf("  Stencil created successfully (1-point).\n");
+
+    // 3. Create Matrix <-- THE CALL WE ARE TESTING
+    HYPRE_StructMatrix matrix;
+    printf("  Attempting HYPRE_StructMatrixCreate...\n");
+    ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, grid, stencil, &matrix);
+    // Check the result carefully
+    if (ierr != 0) {
+        char hypre_error_msg[256];
+        HYPRE_DescribeError(ierr, hypre_error_msg);
+        fprintf(stderr, "FAIL: HYPRE_StructMatrixCreate returned error!\n");
+        fprintf(stderr, "  HYPRE Error: %s (Code: %d)\n", hypre_error_msg, ierr);
+        // Don't use the macro here, just report and proceed to cleanup
+    } else {
+        printf("PASS: HYPRE_StructMatrixCreate succeeded.\n");
+        // Only destroy if create succeeded
+        ierr = HYPRE_StructMatrixDestroy(matrix);
+        HYPRE_CHECK_MSG("HYPRE_StructMatrixDestroy", ierr);
+    }
+
+
+    // Cleanup
+    ierr = HYPRE_StructStencilDestroy(stencil);
+    HYPRE_CHECK_MSG("HYPRE_StructStencilDestroy", ierr);
+    ierr = HYPRE_StructGridDestroy(grid);
+    HYPRE_CHECK_MSG("HYPRE_StructGridDestroy", ierr);
+
+    // Finalize HYPRE
+    ierr = HYPRE_Finalize();
+    HYPRE_CHECK_MSG("HYPRE_Finalize", ierr);
+
+    // Finalize MPI
+    MPI_Finalize();
+
+    // Explicitly return 0 only if the matrix create call did not fail initially
+    return (ierr == 0) ? 0 : 1; // Return 0 on success, 1 on MatrixCreate failure
+}


### PR DESCRIPTION
This PR introduces a standalone Hypre test (`src/props/hypre_test.cpp`) and corresponding GitHub Actions workflow steps to diagnose a persistent runtime error.

**Context:**

Despite successfully building Hypre v2.32.0 with correct OpenMP and MPI flags within the container environment (and Hypre's own `make check` passing), the `tTortuosity` test consistently fails with `HYPRE Error: [Generic error] - Error Code: 1` immediately upon calling `HYPRE_StructMatrixCreate`. Previous debugging steps (simplifying the stencil, verifying grid assembly) did not resolve this specific failure point.

**Changes:**

1.  **Add `src/props/hypre_test.cpp` (Commit `f75db82`):**
    * A minimal C++ program that initializes MPI and Hypre, creates a simple 3D `HYPRE_StructGrid`, defines a 1-point `HYPRE_StructStencil`, and attempts to call `HYPRE_StructMatrixCreate`.
    * Includes explicit error checking after each Hypre call.
2.  **Update `.github/workflows/build-test.yml` (Commit `[Insert second commit hash here]`):**
    * Adds new steps to the CI workflow *before* the main OpenImpala build.
    * These steps compile the standalone `hypre_test.cpp` using `mpic++` inside the container.
    * They then execute the compiled `hypre_test` using `mpirun -np 1`.
    * The workflow logs the output of the compilation and execution, reporting success or failure.

**Purpose:**

The goal of this standalone test is to determine if `HYPRE_StructMatrixCreate` functions correctly in isolation within the container environment (Rocky 8, GCC 11, OpenMPI 4.1.6, Hypre 2.32.0).

* If the standalone test **fails**, it indicates a likely incompatibility or issue within the Hypre library or its interaction with the system environment, despite `make check` passing.
* If the standalone test **succeeds**, it suggests the error encountered in `tTortuosity` is related to the specific way Hypre is being called or integrated within the AMReX/OpenImpala framework.

This test provides a crucial data point to narrow down the root cause of the `HYPRE_StructMatrixCreate` failure.
