### PR TITLE
feat(Tortuosity): Implement geometric masking via percolation analysis

### DIFF
--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -2,6 +2,7 @@
 #define TortuosityHypre_H
 
 #include <string> // Needed for std::string
+#include <vector> // Needed for Vector<IntVect> in helper functions
 
 #include <AMReX.H>
 #include <AMReX_iMultiFab.H>
@@ -10,8 +11,9 @@
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_Geometry.H> // Include Geometry explicitly
 #include <AMReX_Array.H>    // Needed for return type of loV/hiV
+#include <AMReX_IntVect.H>  // Needed for Vector<IntVect>
 
-#include <HYPRE.h>          // Main HYPRE header
+#include <HYPRE.h>           // Main HYPRE header
 #include <HYPRE_struct_ls.h> // Struct interface header (should provide HYPRE_Int)
 
 #include "Tortuosity.H" // Assumed to define OpenImpala::Tortuosity and OpenImpala::Direction
@@ -37,7 +39,7 @@ public:
         GMRES,      /**< HYPRE_StructGMRES */
         FlexGMRES,  /**< HYPRE_StructFlexGMRES */
         PCG,        /**< HYPRE_StructPCG */
-        BiCGSTAB    /**< HYPRE_StructBiCGSTAB */  // <<< ADDED
+        BiCGSTAB    /**< HYPRE_StructBiCGSTAB */
     };
 
     /** Construct new Tortuosity solver using HYPRE.
@@ -47,7 +49,7 @@ public:
     TortuosityHypre(const amrex::Geometry& geom,
                     const amrex::BoxArray& ba,
                     const amrex::DistributionMapping& dm,
-                    const amrex::iMultiFab& mf,
+                    const amrex::iMultiFab& mf_phase_input, // Renamed arg for clarity
                     const amrex::Real vf,
                     const int phase,
                     const OpenImpala::Direction dir,
@@ -78,40 +80,46 @@ public:
 
 private:
 
-    // Private method declarations remain the same...
+    // --- Private Methods ---
     bool solve();
     void setupGrids();
     void setupStencil();
-    void setupMatrixEquation();
+    void setupMatrixEquation(); // Calls modified Fortran routine
     void preconditionPhaseFab();
+    void generateActivityMask(const amrex::iMultiFab& phaseFab, int phaseID, OpenImpala::Direction dir); // <<< NEW
+    void parallelFloodFill(amrex::iMultiFab& reachabilityMask, const amrex::iMultiFab& phaseFab, int phaseID, const amrex::Vector<amrex::IntVect>& seedPoints); // <<< NEW
     void getSolution (amrex::MultiFab& soln, int ncomp=0);
     void getCellTypes(amrex::MultiFab& phi, int ncomp=1);
     void global_fluxes(amrex::Real& fxin, amrex::Real& fxout) const;
 
-    // Member Variables remain the same...
+    // --- Member Variables ---
+    // Configuration
     const SolverType m_solvertype;
     std::string m_resultspath;
     const int m_phase;
     const OpenImpala::Direction m_dir;
     const amrex::Real m_vlo;
     const amrex::Real m_vhi;
-    amrex::Real m_eps = 1e-7;
-    int m_maxiter = 50000;
+    amrex::Real m_eps = 1e-7; // Consider using param parse default from cpp
+    int m_maxiter = 50000; // Consider using param parse default from cpp
     int m_verbose = 0;
     amrex::Real m_vf;
     bool m_write_plotfile;
 
+    // AMReX Data
     const amrex::Geometry& m_geom;
     const amrex::BoxArray& m_ba;
     const amrex::DistributionMapping& m_dm;
-    amrex::iMultiFab m_mf_phase;
-    amrex::MultiFab m_mf_phi;
+    amrex::iMultiFab m_mf_phase;       // Original phase data (aliased from input)
+    amrex::MultiFab m_mf_phi;         // Solution field (potential, etc.)
+    amrex::iMultiFab m_mf_active_mask; // Mask for active/percolating cells <<< NEW
 
+    // State
     amrex::Real m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
     bool m_first_call = true;
 
     // Solver Statistics
-    HYPRE_Int m_num_iterations = -1;    // HYPRE_Int should be defined via HYPRE_struct_ls.h
+    HYPRE_Int m_num_iterations = -1;
     amrex::Real m_final_res_norm = -1.0;
 
     // HYPRE Data Structures
@@ -121,6 +129,34 @@ private:
     HYPRE_StructVector m_b = NULL;
     HYPRE_StructVector m_x = NULL;
 };
+
+
+// --- Updated Fortran Interface Declarations ---
+// Place this outside the class, potentially within the namespace or globally
+// Ensure these match the declarations used for binding in your build system
+extern "C" {
+    void tortuosity_fillmtx(
+        amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit,
+        const int* nval,
+        const int* p, const int* p_lo, const int* p_hi,             // Phase data
+        const int* active_mask, const int* mask_lo, const int* mask_hi, // <<< NEW: Mask data
+        const int* bxlo, const int* bxhi,
+        const int* domlo, const int* domhi,
+        const amrex::Real* dxinv,
+        const amrex::Real* vlo, const amrex::Real* vhi,
+        const int* phase_unused, const int* dir // phase arg now unused in F90 logic
+    );
+
+    void tortuosity_remspot(int* q, const int* q_lo, const int* q_hi, const int* ncomp,
+                            const int* bxlo, const int* bxhi,
+                            const int* domlo, const int* domhi);
+
+    // Add declarations for other Fortran routines called from C++ if needed
+    // void tortuosity_filct(...);
+    // void tortuosity_filbc(...);
+    // void tortuosity_filic(...);
+}
+
 
 } // namespace OpenImpala
 

--- a/src/props/TortuosityHypreFill_F.H
+++ b/src/props/TortuosityHypreFill_F.H
@@ -12,32 +12,37 @@ extern "C" {
  *
  * Fills the HYPRE matrix coefficients ('a'), Right-Hand Side ('rhs'),
  * and initial guess ('xinit') for a single box ('bxlo':'bxhi') based
- * on phase data ('p'), domain boundaries ('domlo':'domhi'), flow direction ('dir'),
- * and boundary values ('vlo', 'vhi'). Implements a 7-point stencil discretization
- * of the Poisson/Laplace equation, handling internal phase boundaries (zero Neumann)
- * and domain boundaries perpendicular to flow (Dirichlet). Uses grid spacing
- * provided via 'dxinv'.
+ * on an activity mask, phase data ('p'), domain boundaries ('domlo':'domhi'),
+ * flow direction ('dir'), and boundary values ('vlo', 'vhi').
+ * Implements a 7-point stencil discretization of the Poisson/Laplace equation
+ * primarily on cells marked active by 'active_mask', handling boundaries between
+ * active and inactive cells (zero Neumann) and domain boundaries perpendicular
+ * to flow (Dirichlet). Uses grid spacing provided via 'dxinv'. Inactive cells
+ * are decoupled (Aii=1, Aij=0, bi=0, xinit=0).
  *
- * @param[out]   a       Pointer to matrix coefficient array (size nval*7, flattened). Stencil: C,W,E,S,N,B,T assumed.
- * @param[out]   rhs     Pointer to RHS array (size nval).
- * @param[out]   xinit   Pointer to initial guess array (size nval).
- * @param[in]    nval    Pointer to number of points in the box (*bxlo to *bxhi). Passed by reference.
- * @param[in]    p       Pointer to phase data array (INTEGER). Accessed as 4D in Fortran (comp_phase=1).
- * @param[in]    p_lo    Pointer to lower bound of p array (Fortran indexing).
- * @param[in]    p_hi    Pointer to upper bound of p array (Fortran indexing, incl. ghosts).
- * @param[in]    bxlo    Pointer to lower bound of current box (Fortran indexing).
- * @param[in]    bxhi    Pointer to upper bound of current box (Fortran indexing).
- * @param[in]    domlo   Pointer to lower bound of domain (Fortran indexing).
- * @param[in]    domhi   Pointer to upper bound of domain (Fortran indexing).
- * @param[in]    dxinv   Pointer to array[3] of inverse grid spacing squared [1/dx^2, 1/dy^2, 1/dz^2].
- * @param[in]    vlo     Pointer to low boundary value (Dirichlet BC). Passed by reference.
- * @param[in]    vhi     Pointer to high boundary value (Dirichlet BC). Passed by reference.
- * @param[in]    phase   Pointer to phase ID considered conductive. Passed by reference.
- * @param[in]    dir     Pointer to direction index (0=X, 1=Y, 2=Z). Passed by reference.
+ * @param[out]  a           Pointer to matrix coefficient array (size nval*7, flattened). Stencil: C,W,E,S,N,B,T assumed.
+ * @param[out]  rhs         Pointer to RHS array (size nval).
+ * @param[out]  xinit       Pointer to initial guess array (size nval).
+ * @param[in]   nval        Pointer to number of points in the box (*bxlo to *bxhi). Passed by reference.
+ * @param[in]   p           Pointer to phase data array (INTEGER). Accessed as 4D in Fortran. (May be optional if mask is sufficient).
+ * @param[in]   p_lo        Pointer to lower bound of p array (Fortran indexing).
+ * @param[in]   p_hi        Pointer to upper bound of p array (Fortran indexing, incl. ghosts).
+ * @param[in]   active_mask Pointer to activity mask array (INTEGER, 1=active, 0=inactive). <<< NEW
+ * @param[in]   mask_lo     Pointer to lower bound of active_mask array (Fortran indexing). <<< NEW
+ * @param[in]   mask_hi     Pointer to upper bound of active_mask array (Fortran indexing, incl. ghosts). <<< NEW
+ * @param[in]   bxlo        Pointer to lower bound of current box (Fortran indexing).
+ * @param[in]   bxhi        Pointer to upper bound of current box (Fortran indexing).
+ * @param[in]   domlo       Pointer to lower bound of domain (Fortran indexing).
+ * @param[in]   domhi       Pointer to upper bound of domain (Fortran indexing).
+ * @param[in]   dxinv       Pointer to array[3] of inverse grid spacing squared [1/dx^2, 1/dy^2, 1/dz^2].
+ * @param[in]   vlo         Pointer to low boundary value (Dirichlet BC). Passed by reference.
+ * @param[in]   vhi         Pointer to high boundary value (Dirichlet BC). Passed by reference.
+ * @param[in]   phase_unused Pointer to phase ID considered conductive (Now potentially unused by Fortran, as mask dictates activity). Passed by reference.
+ * @param[in]   dir         Pointer to direction index (0=X, 1=Y, 2=Z). Passed by reference.
  *
- * @warning Assumes Fortran uses 1-based indexing for components when accessing 'p'.
+ * @warning Assumes Fortran uses 1-based indexing for components when accessing 'p' and 'active_mask'.
  * @warning Ensure 'nval' matches the number of points in the box bxlo:bxhi.
- * @warning Assumed HYPRE stencil convention: 1=Center, 2=-X(W), 3=+X(E), 4=-Y(S), 5=+Y(N), 6=-Z(B), 7=+Z(T). Verify this!
+ * @warning Assumed HYPRE stencil convention: Center,W,E,S,N,B,T matches Fortran indices 1..7 in calculation. Verify this!
  */
 void tortuosity_fillmtx (
     amrex_real* a,
@@ -47,6 +52,9 @@ void tortuosity_fillmtx (
     const int* p,
     const int* p_lo,
     const int* p_hi,
+    const int* active_mask, // <<< NEW
+    const int* mask_lo,     // <<< NEW
+    const int* mask_hi,     // <<< NEW
     const int* bxlo,
     const int* bxhi,
     const int* domlo,
@@ -54,7 +62,7 @@ void tortuosity_fillmtx (
     const amrex_real* dxinv,
     const amrex_real* vlo,
     const amrex_real* vhi,
-    const int* phase,
+    const int* phase_unused, // <<< Renamed
     const int* dir
 );
 


### PR DESCRIPTION
## Problem Description

The HYPRE iterative solvers (BiCGSTAB, FlexGMRES) were encountering significant issues when calculating tortuosity, particularly with multigrid preconditioners (PFMG):
- Immediate solver failures (error code 1, NaN residuals).
- Slow or non-convergence even after fixing explicit zero diagonals caused by isolated conducting cells.

These issues indicated that the linear system derived from applying the Laplace/Poisson equation across the entire domain (including non-conducting regions and non-percolating conducting regions) was severely ill-conditioned, making it unstable for robust solution, especially with AMG preconditioners.

## Solution: Geometric Masking

This PR introduces a geometric isolation strategy to improve the problem formulation by solving the PDE only on the physically relevant **percolating network** of the conducting phase.

**Key Features & Implementation:**

1.  **Percolation Analysis:**
    - Implemented via two parallel flood fills (reachability searches) starting from the conducting phase cells on the inlet and outlet boundaries respectively (`parallelFloodFill` method in `TortuosityHypre.cpp`). This uses an iterative neighbor-checking approach with ghost cell exchanges.
    - An integer MultiFab, `m_mf_active_mask`, is generated (`generateActivityMask` method in `TortuosityHypre.cpp`). Cells are marked as `active` (1) only if they are reachable from *both* the inlet and outlet through the conducting phase; otherwise, they are marked `inactive` (0).

2.  **Masked Matrix Assembly:**
    - The `tortuosity_fillmtx` Fortran routine (`TortuosityHypreFill.F90`) now accepts the `active_mask` as input.
    - **Inactive Cells (mask=0):** Explicitly decoupled from the system (Aii=1, Aij=0, bi=0, xinit=0).
    - **Active Cells (mask=1):** The Laplace/Poisson equation is assembled, but connections (off-diagonal matrix entries Aij) are only created to *other active neighbors*. Neumann BCs (zero flux) are implicitly enforced at the boundary between active and inactive cells by omitting the connection terms. The diagonal Aii is calculated as the sum of coefficients for active neighbors.
    - Dirichlet boundary conditions are still applied by overwriting rows for cells on the relevant domain faces.

3.  **Masked Flux Calculation:**
    - The `global_fluxes` method in `TortuosityHypre.cpp` was updated to use the `active_mask` when calculating flux across the domain boundaries, ensuring only flux through active cells contributes.

4.  **Interface Updates:**
    - Modified `TortuosityHypre.H` to declare the new mask member variable and helper methods.
    - Updated the Fortran subroutine signature in `TortuosityHypreFill.F90` and its C interface declaration in `TortuosityHypreFill_F.H` to include the mask arguments.

5.  **Debugging:** Added an optional runtime parameter `tortuosity.write_debug_mask = 1` to output the generated mask to a plotfile for verification.

## Expected Benefits

- **Improved Robustness:** Significantly reduces ill-conditioning by removing non-physical degrees of freedom, leading to more stable solver behavior.
- **Better Convergence:** Faster and more reliable convergence expected for iterative solvers.
- **Preconditioner Compatibility:** Increases the likelihood that advanced preconditioners like PFMG or SMG will function correctly and effectively.
- **Physical Accuracy:** Solves the potential field only on the network relevant to transport.

## Testing Recommendations

- Verify the generated `active_mask` visually using `write_debug_mask=1`.
- Re-test previously failing solver/preconditioner combinations (e.g., FlexGMRES + Tuned PFMG, BiCGSTAB + Tuned PFMG).
- Compare convergence speed and results with previous attempts (unpreconditioned, Jacobi preconditioned).

**Files Changed:**

- `openImpala/src/props/TortuosityHypre.H`
- `openImpala/src/props/TortuosityHypre.cpp`
- `openImpala/src/props/TortuosityHypreFill_F.H`
- `openImpala/src/props/TortuosityHypreFill.F90`