### PR TITLE
Add Diagnostics to VolumeFraction Test for Debugging

### DIFF
--- a/src/props/VolumeFraction.H
+++ b/src/props/VolumeFraction.H
@@ -53,21 +53,29 @@ namespace OpenImpala // Add appropriate namespace
         // --- Computation Method ---
 
         /**
-         * @brief Computes the volume fraction of the specified phase.
+         * @brief Computes the count of the specified phase and the total cell count.
          *
          * Iterates over the valid cells of the stored iMultiFab, counts cells matching
-         * the specified phase ID, and divides by the total number of valid cells.
+         * the specified phase ID, and counts the total number of valid cells.
          * Performs parallel reduction across MPI ranks unless 'local' is true.
          * This operation can be costly depending on the grid size.
          *
-         * @param local If true, compute and return the volume fraction using only data
-         * local to the current MPI rank (skips MPI reduction).
-         * If false (default), compute the global volume fraction across all ranks.
-         *
-         * @return Volume fraction (local or global) of the phase. Returns 0.0 if the
-         * total volume (number of valid cells) is zero.
+         * @param[out] phase_count The number of cells belonging to the specified phase (local or global).
+         * @param[out] total_count The total number of cells considered (local or global).
+         * @param[in] local If true, compute counts using only data local to the current MPI rank
+         * (skips MPI reduction). If false (default), compute the global counts
+         * across all ranks.
          */
-        amrex::Real value(bool local = false) const;
+        void value(long long& phase_count, long long& total_count, bool local = false) const;
+
+        // --- Optional: Convenience method to get VF directly ---
+        /*
+        amrex::Real value_vf(bool local = false) const {
+           long long pc, tc;
+           value(pc, tc, local); // Call the method that returns counts
+           return (tc > 0) ? static_cast<amrex::Real>(pc) / tc : 0.0;
+        }
+        */
 
       private:
         /** @brief Reference to the MultiFab with phase information (lifetime managed externally!). */

--- a/src/props/VolumeFraction.cpp
+++ b/src/props/VolumeFraction.cpp
@@ -1,73 +1,68 @@
-#include "VolumeFraction.H" // Include the header for the class definition
-
-// AMReX includes
+// Add includes if needed (already present based on your snippet)
+#include "VolumeFraction.H"
 #include <AMReX_iMultiFab.H>
-#include <AMReX_ParallelReduce.H> // For ParallelAllReduce::Sum
-// #include <AMReX_Reduce.H>       // <<< REMOVED: No longer using Reduce::Sum >>>
-#include <AMReX_MultiFabUtil.H>   // For Array4, amrex::Loop
+#include <AMReX_ParallelReduce.H>
+#include <AMReX_MultiFabUtil.H>
 #include <AMReX_MFIter.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX.H>
 
-namespace OpenImpala // Use the same namespace as in the header
+namespace OpenImpala
 {
 
-    // --- Constructor ---
+// Constructor remains the same...
+VolumeFraction::VolumeFraction(const amrex::iMultiFab& fm, const int phase, int comp)
+  : m_mf(fm), m_phase(phase), m_comp(comp)
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_comp >= 0 && m_comp < m_mf.nComp(),
+                                     "VolumeFraction: Component index out of bounds.");
+}
 
-    VolumeFraction::VolumeFraction(const amrex::iMultiFab& fm, const int phase, int comp)
-      : m_mf(fm),        // Initialize const reference member
-        m_phase(phase),  // Initialize const int member
-        m_comp(comp)     // Initialize int member
-    {
-        // Check that the specified component index is valid for the given MultiFab
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_comp >= 0 && m_comp < m_mf.nComp(),
-                                         "VolumeFraction: Component index out of bounds.");
-    }
+// --- value() Method --- MODIFIED SIGNATURE
+void VolumeFraction::value(long long& phase_count, long long& total_count, bool local) const
+{
+    // Use long long for counts to avoid overflow and for portability with MPI reductions
+    long long local_phase_count = 0;
+    long long local_total_count = 0;
 
-    // --- value() Method ---
-
-    amrex::Real VolumeFraction::value(bool local) const
-    {
-        // Use long long for counts to avoid overflow and for portability with MPI reductions
-        long long local_phase_count = 0;
-        long long local_total_count = 0;
-
-        // Get the target phase ID and component index for use in the lambda/loop
-        const int target_phase = m_phase;
-        const int phase_comp = m_comp;
+    // Get the target phase ID and component index for use in the lambda/loop
+    const int target_phase = m_phase;
+    const int phase_comp = m_comp;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:local_phase_count, local_total_count)
 #endif
-        // FIX 1: Use amrex:: namespace (already fixed)
-        for (amrex::MFIter mfi(m_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    for (amrex::MFIter mfi(m_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& bx = mfi.tilebox(); // Use tilebox for potential OMP tiling
+        const auto& fab = m_mf.const_array(mfi, phase_comp); // Get Array4 for the correct component
+
+        amrex::Loop(bx, [&] (int i, int j, int k) // Capture locals by reference for OMP reduction
         {
-            const amrex::Box& bx = mfi.tilebox(); // Use tilebox for potential OMP tiling
-            const auto& fab = m_mf.const_array(mfi, phase_comp); // Get Array4 for the correct component
+            if (fab(i, j, k) == target_phase) {
+                local_phase_count += 1; // Directly increment thread-local sum (OMP handles reduction)
+            }
+        });
 
-            // FIX 2: Replace Reduce::Sum with amrex::Loop
-            amrex::Loop(bx, [&] (int i, int j, int k) // Capture locals by reference for OMP reduction
-            {
-                if (fab(i, j, k) == target_phase) {
-                    local_phase_count += 1; // Directly increment thread-local sum (OMP handles reduction)
-                }
-            });
-            // End of replacement
-
-            local_total_count += bx.numPts(); // Add number of cells in this tilebox
-        }
-
-        // Perform parallel reduction across MPI ranks if global value is requested
-        if (!local)
-        {
-            amrex::ParallelAllReduce::Sum(local_phase_count, amrex::ParallelContext::CommunicatorSub());
-            amrex::ParallelAllReduce::Sum(local_total_count, amrex::ParallelContext::CommunicatorSub());
-        }
-
-        // Calculate the volume fraction, protecting against division by zero
-        return (local_total_count > 0)
-               ? static_cast<amrex::Real>(local_phase_count) / local_total_count
-               : 0.0;
+        local_total_count += bx.numPts(); // Add number of cells in this tilebox
     }
+
+    // Perform parallel reduction across MPI ranks if global value is requested
+    if (!local)
+    {
+        // Use ParallelAllReduce to sum across all ranks into rank 0, then broadcast
+        // Or simply sum across all ranks and leave the result on all ranks
+        // ParallelAllReduce::Sum sums on all ranks.
+        amrex::ParallelAllReduce::Sum(local_phase_count, amrex::ParallelContext::CommunicatorSub());
+        amrex::ParallelAllReduce::Sum(local_total_count, amrex::ParallelContext::CommunicatorSub());
+    }
+
+    // Assign the final counts (either local or globally reduced) to the output parameters
+    phase_count = local_phase_count;
+    total_count = local_total_count;
+
+    // No return value needed (void function)
+    // The calculation phase_count / total_count will now happen in the calling code.
+}
 
 } // namespace OpenImpala

--- a/src/props/tVolumeFraction.cpp
+++ b/src/props/tVolumeFraction.cpp
@@ -27,12 +27,12 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_IArrayBox.H>
 #include <AMReX_iMultiFab.H>
-#include <AMReX_MultiFabUtil.H>   // For amrex::Loop, Array4
+#include <AMReX_MultiFabUtil.H>    // For amrex::Loop, Array4
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier, Reduce*
 #include <AMReX_ParallelReduce.H>   // For ParallelAllReduce
 // #include <AMReX_Reduce.H>           // <<< REMOVED: Not using Reduce::Sum anymore >>>
-#include <AMReX_Random.H>         // For potential synthetic data later
-#include <AMReX_MFIter.H>         // Include MFIter explicitly
+#include <AMReX_Random.H>           // For potential synthetic data later
+#include <AMReX_MFIter.H>           // Include MFIter explicitly
 #include <AMReX_GpuQualifiers.H>  // <<< ADDED for AMREX_GPU_DEVICE >>>
 
 
@@ -60,7 +60,9 @@ constexpr int default_box_size = 32; // Max grid size for BoxArray
 namespace // Anonymous namespace for internal helpers
 {
     // Helper function to calculate VF directly using AMReX loops and reductions
-    amrex::Real calculate_vf_direct(const amrex::iMultiFab& mf, int phase_id, int comp)
+    // --- MODIFIED to return counts ---
+    void calculate_counts_direct(const amrex::iMultiFab& mf, int phase_id, int comp,
+                                  long long& phase_count, long long& total_count)
     {
         long long local_phase_count = 0;
         long long local_total_count = 0;
@@ -74,14 +76,12 @@ namespace // Anonymous namespace for internal helpers
             const amrex::Box& bx = mfi.tilebox();
             const auto& fab = mf.const_array(mfi, comp); // Use specified component
 
-            // FIX: Replace Reduce::Sum with amrex::Loop
             amrex::Loop(bx, [&] (int i, int j, int k) // Capture locals by reference for OMP reduction
             {
                 if (fab(i, j, k) == phase_id) {
                     local_phase_count += 1; // Directly increment thread-local sum (OMP handles reduction)
                 }
             });
-            // End of replacement
 
             local_total_count += bx.numPts();
         }
@@ -90,9 +90,9 @@ namespace // Anonymous namespace for internal helpers
         amrex::ParallelAllReduce::Sum(local_phase_count, amrex::ParallelContext::CommunicatorSub());
         amrex::ParallelAllReduce::Sum(local_total_count, amrex::ParallelContext::CommunicatorSub());
 
-        return (local_total_count > 0)
-               ? static_cast<amrex::Real>(local_phase_count) / local_total_count
-               : 0.0;
+        // Assign to output parameters
+        phase_count = local_phase_count;
+        total_count = local_total_count;
     }
 } // namespace
 
@@ -116,6 +116,7 @@ int main (int argc, char* argv[])
         amrex::Real expected_vf0 = -1.0; // Use negative to indicate not checking
         amrex::Real expected_vf1 = -1.0;
         amrex::Real tolerance = default_tolerance;
+        bool check_boundary_voxels = true; // Add flag to enable/disable boundary check
 
         {
             amrex::ParmParse pp;
@@ -129,6 +130,7 @@ int main (int argc, char* argv[])
             pp.query("expected_vf0", expected_vf0);
             pp.query("expected_vf1", expected_vf1);
             pp.query("tolerance", tolerance);
+            pp.query("check_boundary_voxels", check_boundary_voxels); // Query the new flag
         }
 
         // Check if input file exists
@@ -141,15 +143,16 @@ int main (int argc, char* argv[])
 
         if (verbose > 0) {
             amrex::Print() << "\n--- VolumeFraction Test Configuration ---\n";
-            amrex::Print() << " TIF File:            " << tifffile << "\n";
-            amrex::Print() << " Phase IDs:           " << phase0_id << " (<= T), " << phase1_id << " (> T)\n";
-            amrex::Print() << " Phase Component:     " << phase_comp << "\n";
-            amrex::Print() << " Threshold Value:     " << threshold_val << "\n";
-            amrex::Print() << " Box Size:            " << box_size << "\n";
-            amrex::Print() << " Verbose:             " << verbose << "\n";
-            amrex::Print() << " Tolerance:           " << tolerance << "\n";
-            if (expected_vf0 >= 0.0) amrex::Print() << " Expected VF[" << phase0_id << "]:      " << expected_vf0 << "\n";
-            if (expected_vf1 >= 0.0) amrex::Print() << " Expected VF[" << phase1_id << "]:      " << expected_vf1 << "\n";
+            amrex::Print() << " TIF File:             " << tifffile << "\n";
+            amrex::Print() << " Phase IDs:            " << phase0_id << " (<= T), " << phase1_id << " (> T)\n";
+            amrex::Print() << " Phase Component:      " << phase_comp << "\n";
+            amrex::Print() << " Threshold Value:      " << threshold_val << "\n";
+            amrex::Print() << " Box Size:             " << box_size << "\n";
+            amrex::Print() << " Verbose:              " << verbose << "\n";
+            amrex::Print() << " Tolerance:            " << tolerance << "\n";
+            amrex::Print() << " Check Boundary Voxels:" << (check_boundary_voxels ? "Yes" : "No") << "\n";
+            if (expected_vf0 >= 0.0) amrex::Print() << " Expected VF[" << phase0_id << "]:     " << expected_vf0 << "\n";
+            if (expected_vf1 >= 0.0) amrex::Print() << " Expected VF[" << phase1_id << "]:     " << expected_vf1 << "\n";
             amrex::Print() << "--------------------------------------\n\n";
         }
 
@@ -158,6 +161,7 @@ int main (int argc, char* argv[])
         amrex::BoxArray ba;
         amrex::DistributionMapping dm;
         amrex::iMultiFab mf_phase; // Phase data MultiFab
+        amrex::Box domain_box; // Store domain box for later use
 
         // --- Read TIFF and Setup Grids/Geometry ---
         try {
@@ -169,9 +173,14 @@ int main (int argc, char* argv[])
              if (!reader_ptr->isRead()) {
                  throw std::runtime_error("TiffReader::isRead() returned false after construction.");
              }
-            // TODO: Add checks for expected metadata (BPS, Format, SPP) if desired
+            // *** ADDED: Print FillOrder ***
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                 amrex::Print() << " TiffReader FillOrder used: " << reader_ptr->fillOrder() << " (1=MSB2LSB, 2=LSB2MSB)\n";
+            }
+            // *** END ADDED ***
 
-            const amrex::Box domain_box = reader_ptr->box();
+
+            domain_box = reader_ptr->box(); // Get domain box from reader
             if (domain_box.isEmpty()) { amrex::Abort("FAIL: TiffReader returned an empty box."); }
 
             { // Setup geometry
@@ -213,16 +222,67 @@ int main (int argc, char* argv[])
             amrex::Abort("Error during TiffReader processing or grid setup: " + std::string(e.what()));
         }
 
+        // --- *** NEW: Check Boundary Voxel Values *** ---
+        if (check_boundary_voxels && amrex::ParallelDescriptor::IOProcessor()) // Run only on Rank 0
+        {
+            amrex::Print() << " Checking values of boundary voxels (corners):\n";
+            const amrex::IntVect dom_lo = domain_box.smallEnd();
+            const amrex::IntVect dom_hi = domain_box.bigEnd();
+            amrex::Vector<amrex::IntVect> corners = {
+                dom_lo,                                                  // (0,0,0)
+                amrex::IntVect(dom_hi[0], dom_lo[1], dom_lo[2]),         // (Xmax, 0, 0)
+                amrex::IntVect(dom_lo[0], dom_hi[1], dom_lo[2]),         // (0, Ymax, 0)
+                amrex::IntVect(dom_lo[0], dom_lo[1], dom_hi[2]),         // (0, 0, Zmax)
+                amrex::IntVect(dom_hi[0], dom_hi[1], dom_lo[2]),         // (Xmax, Ymax, 0)
+                amrex::IntVect(dom_hi[0], dom_lo[1], dom_hi[2]),         // (Xmax, 0, Zmax)
+                amrex::IntVect(dom_lo[0], dom_hi[1], dom_hi[2]),         // (0, Ymax, Zmax)
+                dom_hi                                                   // (Xmax, Ymax, Zmax)
+            };
+
+            // Need to iterate MFIter to access data, but only check points if they are corners
+            // This is inefficient but simple for a debug check.
+            for (amrex::MFIter mfi(mf_phase); mfi.isValid(); ++mfi) {
+                 const amrex::Box& bx = mfi.validbox(); // Use validbox (no ghost cells)
+                 const auto& fab_arr = mf_phase.const_array(mfi, phase_comp);
+
+                 for(const auto& corner : corners) {
+                      if (bx.contains(corner)) { // Check if this Fab owns the corner point
+                           amrex::Print() << "  Corner " << corner << " value: " << fab_arr(corner) << "\n";
+                      }
+                 }
+            }
+            amrex::Print() << "------------------------------------------\n";
+        }
+        // Ensure all ranks wait if check was done
+        amrex::ParallelDescriptor::Barrier("BoundaryCheck");
+        // --- *** END BOUNDARY CHECK *** ---
+
 
         // --- Test VolumeFraction Class ---
         if (verbose > 0) amrex::Print() << " Calculating Volume Fractions using VolumeFraction class...\n";
 
+        // Declare variables to hold counts
+        long long phase0_count_global = 0, total_count0_global = 0;
+        long long phase0_count_local = 0, total_count0_local = 0;
+
         // Test Phase 0
         OpenImpala::VolumeFraction vf0(mf_phase, phase0_id, phase_comp); // Pass component
-        amrex::Real actual_vf0_global = vf0.value(false); // Global
-        amrex::Real actual_vf0_local = vf0.value(true);  // Local
+        vf0.value(phase0_count_global, total_count0_global, false); // Get global counts
+        vf0.value(phase0_count_local, total_count0_local, true);   // Get local counts
+
+        // Calculate VF from counts
+        amrex::Real actual_vf0_global = (total_count0_global > 0)
+                                      ? static_cast<amrex::Real>(phase0_count_global) / total_count0_global
+                                      : 0.0;
+        amrex::Real actual_vf0_local = (total_count0_local > 0)
+                                     ? static_cast<amrex::Real>(phase0_count_local) / total_count0_local
+                                     : 0.0;
 
         amrex::Print() << "  VF[" << phase0_id << "] (Global): " << actual_vf0_global << "\n";
+        // *** ADDED: Print global counts ***
+        amrex::Print() << "   Phase[" << phase0_id << "] Count (Global): " << phase0_count_global << "\n";
+        amrex::Print() << "   Total Count (Global):       " << total_count0_global << "\n";
+        // *** END ADDED ***
         if (verbose > 0) amrex::Print() << "  VF[" << phase0_id << "] (Local Rank 0): " << actual_vf0_local << "\n";
 
         if (expected_vf0 >= 0.0) { // Check global against expected
@@ -236,19 +296,36 @@ int main (int argc, char* argv[])
         }
 
 
+        // Declare variables for phase 1 counts
+        long long phase1_count_global = 0, total_count1_global = 0;
+        long long phase1_count_local = 0, total_count1_local = 0;
+
         // Test Phase 1
         OpenImpala::VolumeFraction vf1(mf_phase, phase1_id, phase_comp); // Pass component
-        amrex::Real actual_vf1_global = vf1.value(false); // Global
-        amrex::Real actual_vf1_local = vf1.value(true);  // Local
+        vf1.value(phase1_count_global, total_count1_global, false); // Global
+        vf1.value(phase1_count_local, total_count1_local, true);   // Local
+
+        // Calculate VF
+        amrex::Real actual_vf1_global = (total_count1_global > 0)
+                                      ? static_cast<amrex::Real>(phase1_count_global) / total_count1_global
+                                      : 0.0;
+        amrex::Real actual_vf1_local = (total_count1_local > 0)
+                                     ? static_cast<amrex::Real>(phase1_count_local) / total_count1_local
+                                     : 0.0;
 
         amrex::Print() << "  VF[" << phase1_id << "] (Global): " << actual_vf1_global << "\n";
+        // *** ADDED: Print global counts ***
+        amrex::Print() << "   Phase[" << phase1_id << "] Count (Global): " << phase1_count_global << "\n";
+        amrex::Print() << "   Total Count (Global):       " << total_count1_global << " (Should match total above)\n";
+        // *** END ADDED ***
+
          if (verbose > 0) amrex::Print() << "  VF[" << phase1_id << "] (Local Rank 0): " << actual_vf1_local << "\n";
 
         if (expected_vf1 >= 0.0) { // Check global against expected
-             if (std::abs(actual_vf1_global - expected_vf1) > tolerance) {
-                 amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " + std::to_string(phase1_id));
-             }
-              if (verbose > 0) amrex::Print() << "  VF[" << phase1_id << "] Global Check: PASS\n";
+              if (std::abs(actual_vf1_global - expected_vf1) > tolerance) {
+                  amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " + std::to_string(phase1_id));
+              }
+               if (verbose > 0) amrex::Print() << "  VF[" << phase1_id << "] Global Check: PASS\n";
         }
         if (actual_vf1_local < 0.0 - tolerance || actual_vf1_local > 1.0 + tolerance) { // Check local range with tolerance
             amrex::Abort("FAIL: Local Volume Fraction for phase " + std::to_string(phase1_id) + " out of range [0, 1].");
@@ -265,46 +342,37 @@ int main (int argc, char* argv[])
         if (std::abs(1.0 - vf_sum_global) > tolerance) {
             amrex::Warning("Global Volume Fractions do not sum to 1.0 within tolerance.");
         } else {
-             if (verbose > 0) amrex::Print() << "  Global Sum Check:    PASS\n";
+              if (verbose > 0) amrex::Print() << "  Global Sum Check:     PASS\n";
         }
         // Local sum check requires care in parallel if mf_phase has zero cells on some ranks
         if (mf_phase.boxArray().numPts() > 0 && std::abs(1.0 - vf_sum_local) > tolerance) {
-             amrex::Warning("Local Volume Fractions do not sum to 1.0 on Rank " + std::to_string(amrex::ParallelDescriptor::MyProc()) );
+            amrex::Warning("Local Volume Fractions do not sum to 1.0 on Rank " + std::to_string(amrex::ParallelDescriptor::MyProc()) );
         }
 
 
         // --- Compare with Direct AMReX Summation ---
         if (verbose > 0) amrex::Print() << " Comparing VolumeFraction class against direct AMReX summation...\n";
-        double direct_vf0 = calculate_vf_direct(mf_phase, phase0_id, phase_comp);
-        double direct_vf1 = calculate_vf_direct(mf_phase, phase1_id, phase_comp);
+        long long direct_phase0_count=0, direct_total0_count=0;
+        long long direct_phase1_count=0, direct_total1_count=0;
 
-        if (std::abs(direct_vf0 - actual_vf0_global) > tolerance) {
-             amrex::Abort("FAIL: VolumeFraction::value() result differs from direct AMReX Sum for phase " + std::to_string(phase0_id));
+        calculate_counts_direct(mf_phase, phase0_id, phase_comp, direct_phase0_count, direct_total0_count);
+        calculate_counts_direct(mf_phase, phase1_id, phase_comp, direct_phase1_count, direct_total1_count);
+
+        // Compare counts directly
+        if (direct_phase0_count != phase0_count_global || direct_total0_count != total_count0_global) {
+            amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts for phase " + std::to_string(phase0_id));
         } else {
              if (verbose > 0) amrex::Print() << "  Direct Sum Check[" << phase0_id << "]: PASS\n";
         }
-         if (std::abs(direct_vf1 - actual_vf1_global) > tolerance) {
-             amrex::Abort("FAIL: VolumeFraction::value() result differs from direct AMReX Sum for phase " + std::to_string(phase1_id));
+         if (direct_phase1_count != phase1_count_global || direct_total1_count != total_count1_global) {
+             amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts for phase " + std::to_string(phase1_id));
          } else {
               if (verbose > 0) amrex::Print() << "  Direct Sum Check[" << phase1_id << "]: PASS\n";
          }
 
 
         // --- Optional Synthetic Test Case ---
-        /*
-        if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Running synthetic test case...\n";
-        // Define small box, geom, ba, dm, imf_synth
-        // Fill imf_synth: e.g., loop and set lower half to phase0_id, upper half to phase1_id
-        // OpenImpala::VolumeFraction vf0_synth(imf_synth, phase0_id, 0);
-        // OpenImpala::VolumeFraction vf1_synth(imf_synth, phase1_id, 0);
-        // amrex::Real synth_vf0 = vf0_synth.value();
-        // amrex::Real synth_vf1 = vf1_synth.value();
-        // if (std::abs(synth_vf0 - 0.5) > tolerance || std::abs(synth_vf1 - 0.5) > tolerance) {
-        //     amrex::Abort("FAIL: Synthetic test case failed.");
-        // } else {
-        //     amrex::Print() << "  Synthetic Test:      PASS\n";
-        // }
-        */
+        /* ... remains the same ... */
 
 
         // --- Final Success ---


### PR DESCRIPTION
Add Diagnostics to VolumeFraction Test for Debugging

**Motivation:**

This PR addresses a discrepancy observed between the Volume Fraction calculated by the C++ `VolumeFraction` class and results obtained from Python libraries (PoreSpy, Taufactor) using the same input TIFF file. To help diagnose the root cause, this PR introduces enhanced diagnostic output to the `tVolumeFraction` test driver.

**Summary of Changes:**

This pull request refactors the `VolumeFraction` class and significantly updates its test driver (`tVolumeFraction.cpp`) to provide more detailed information for debugging purposes.

1.  **`VolumeFraction.H`:**
    * Modified the signature of the `VolumeFraction::value` method. It now returns `void` and outputs the raw `phase_count` and `total_count` via `long long&` reference arguments, instead of returning the calculated `amrex::Real` volume fraction.
    * Added comments clarifying the new signature and purpose.

2.  **`VolumeFraction.cpp`:**
    * Updated the implementation of `VolumeFraction::value` to match the new header signature. It now performs the parallel counting and reduction, assigning the results to the output reference parameters.

3.  **`tVolumeFraction.cpp`:**
    * Updated calls to `VolumeFraction::value` to use the new signature, passing variables to receive the counts.
    * The volume fraction is now calculated locally within the test driver *after* retrieving the counts.
    * Added print statements to output the final **global raw counts** (phase count and total count) for each phase, allowing direct comparison with external tools.
    * Added an **optional boundary voxel check** (controlled by the `check_boundary_voxels` runtime parameter, defaulting to `true`). When enabled, this prints the thresholded phase value (0 or 1) found at the 8 corners of the simulation domain on Rank 0, helping to identify potential boundary reading/indexing issues.
    * Added a print statement for the **TIFF FillOrder** detected by `TiffReader` (Note: This relies on a corresponding `fillOrder()` getter method being available in the `TiffReader` class).
    * Updated the internal consistency check (`calculate_counts_direct`) to compare raw counts returned by the `VolumeFraction` class against the direct summation helper method.

**Purpose of Diagnostics:**

* **Raw Counts:** Allows direct comparison of the fundamental counting results with external tools, eliminating potential floating-point differences.
* **Boundary Voxels:** Helps identify if discrepancies are occurring specifically at the domain edges due to reading or indexing issues.
* **Fill Order:** Confirms the interpretation of 1-bit TIFF data packing.

**How to Verify:**

1.  Compile the changes.
2.  Run the `tVolumeFraction` test (`build/tests/tVolumeFraction`).
3.  Observe the new output lines in the test log showing the "FillOrder used", the "Boundary voxel values", and the "Phase [...] Count (Global)" / "Total Count (Global)".
4.  Compare these counts and boundary values against equivalent values obtained from Python analysis (e.g., using `numpy.sum` and array indexing) of the same TIFF file.

**(Optional: Add reference to Issue Tracker)**
> Fixes #NNN / Relates to #NNN