### PR TITLE
Fix(app): Resolve Tortuosity Flux Errors and Add Developer Workflow

### DIFF
--- a/.github/workflows/build-deps.yaml
+++ b/.github/workflows/build-deps.yaml
@@ -1,0 +1,40 @@
+# .github/workflows/build-deps.yml
+name: Build and Release Dependency SIF
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag for this dependency release (e.g., deps-v1.0)'
+        required: true
+        default: 'deps-v1.0'
+
+jobs:
+  build-and-release-deps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create a release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.2.5
+
+      - name: Build Dependency SIF
+        run: |
+          echo "Building dependency_image.sif from containers/Singularity.deps.def..."
+          sudo apptainer build dependency_image.sif containers/Singularity.deps.def
+
+      - name: Create GitHub Release and Upload Dependency SIF
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: Dependency Container ${{ github.event.inputs.release_tag }}
+          body: "This release contains the pre-built dependency container (dependency_image.sif) for developer use. It is NOT the application binary."
+          files: dependency_image.sif
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This pull request contains two important updates:
1.  A critical bug fix to the `Diffusion` driver that resolves the "Flux not conserved" error in parallel tortuosity calculations.
2.  A new GitHub Actions workflow to provide an easier method for developers to build the necessary dependency container.

---

### 1. Fix: Non-Periodic Geometry for Tortuosity Solver

**Problem:**
The `flow_through` tortuosity calculation was failing in parallel with `NaN` results. The root cause was a fundamental geometry mismatch: the main application geometry (`geom_full`) is defined as **periodic** for `homogenization` calculations, but the tortuosity solver requires a **non-periodic** geometry to have distinct inlet and outlet faces.

When running in parallel, passing the periodic geometry to the solver caused `FillBoundary` calls to incorrectly wrap data from the outlet face to the inlet ghost cells, corrupting the gradient calculation and leading to a catastrophic failure of the flux conservation check.

**Solution:**
A new, explicitly non-periodic `amrex::Geometry` object (`geom_tortuosity`) is now created within the `flow_through` logic block in `Diffusion.cpp`. This correct, non-periodic geometry is now passed to the `TortuosityHypre` constructor.

**Impact:**
This change resolves the flux conservation errors and allows for correct, physically valid tortuosity simulations when running in parallel.

---

### 2. Feat: Developer Dependency Build Workflow

**Problem:**
Developers working on non-Linux machines or on HPC systems without `sudo` access cannot easily build the `dependency_image.sif` container required for compiling the application. Existing methods like `--remote` builder or `--fakeroot` can be blocked by system firewalls or `GLIBC` incompatibilities.

**Solution:**
A new manual workflow, `.github/workflows/build-deps.yaml`, has been added. This workflow leverages GitHub's infrastructure to:
1.  Build the `dependency_image.sif` from the `containers/Singularity.deps.def` recipe.
2.  Create a new GitHub Release with a user-specified tag (e.g., `deps-v1.0`).
3.  Attach the resulting `dependency_image.sif` as a downloadable release asset.

**How to Use:**
A developer can now go to the "Actions" tab, select "Build and Release Dependency SIF", and run the workflow manually to get a pre-built, known-good development environment.

**Impact:**
This provides a reliable and straightforward method for developers to obtain the necessary build environment without needing local root privileges, bypassing common HPC and local system constraints.